### PR TITLE
vendor: adds pkg/errors and updates

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3d01e11f27d1627c3c059031c883be8c5070ad0c5ae33151e2201ccd88d5c111
-updated: 2016-07-20T22:51:50.326855536-06:00
+hash: a2512d9698a2a2a327b164d3340d635c2e74cf7d89913a9ac992088370d35cab
+updated: 2016-08-02T16:21:22.534673078-06:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: a11ddd7a070196035bc94b6c04a2a0114c06a395
@@ -23,12 +23,12 @@ imports:
   - internal/protocol/xml/xmlutil
   - internal/protocol/rest
 - name: github.com/Azure/azure-sdk-for-go
-  version: 2cdbb8553a20830507e4178b4d0803794136dde7
+  version: 87de771fcdf5ec4341f3842f74b5bb98652b10f7
   subpackages:
   - arm/compute
   - arm/network
 - name: github.com/Azure/go-autorest
-  version: 9c64b6583716b13caa7f85398c3331229c38f168
+  version: d09c6ea2240178fb3942d698d432dc00ea7e08e6
   subpackages:
   - autorest/azure
   - autorest
@@ -39,13 +39,13 @@ imports:
   subpackages:
   - quantile
 - name: github.com/BurntSushi/toml
-  version: f0aeabca5a127c4078abb8c8d64298b147264b55
+  version: 99064174e013895bbd9b025c31100bd1d9b590ca
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/dgrijalva/jwt-go
-  version: f0777076321ab64f6efc15a82d9d23b98539b943
+  version: 63734eae1ef55eaac06fdc0f312615f2e321e273
 - name: github.com/eapache/go-resiliency
   version: b86b1ec0dd4209a588dc1285cdd471e73525c0b3
   subpackages:
@@ -57,13 +57,13 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb
 - name: github.com/gocql/gocql
-  version: b7b8a0e04b0cb0ca0b379421c58ec6fab9939b85
+  version: b2caded3d0f457e42515c06d4092c02055cebaa0
   subpackages:
   - internal/lru
   - internal/murmur
   - internal/streams
 - name: github.com/golang/protobuf
-  version: 3852dcfda249c2097355a6aabb199a28d97b30df
+  version: c3cefd437628a0b7d31b34fe44b3a7a540e98527
   subpackages:
   - proto
 - name: github.com/golang/snappy
@@ -71,13 +71,13 @@ imports:
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/hashicorp/consul
-  version: 6e061b2d580d80347b7c5c4dfc8730de7403a145
+  version: 6a3076296543515fbf8892161d80c25f2c828435
   subpackages:
   - api
 - name: github.com/hashicorp/go-cleanhttp
   version: 875fb671b3ddc66f8e2f0acc33829c8cb989a38d
 - name: github.com/hashicorp/hcl
-  version: 61f5143284c041681f76a5b63efcb232aaa94737
+  version: d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -95,23 +95,25 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/julienschmidt/httprouter
-  version: 77366a47451a56bb3ba682481eed85b64fea14e8
+  version: fb79d6a91d3e4a9ecb6d945b218d78fc0d9b1939
 - name: github.com/klauspost/crc32
   version: 19b0b332c9e4516a6370a0456e6182c3b5036720
 - name: github.com/magiconair/properties
-  version: c265cfa48dda6474e208715ca93e987829f572f8
+  version: b3f6dd549956e8a61ea4a686a1c02a33d5bdda4b
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/miekg/dns
-  version: 5d001d020961ae1c184f9f8152fdc73810481677
+  version: db96a2b759cdef4f11a34506a42eb8d1290c598e
 - name: github.com/mitchellh/mapstructure
-  version: d2dd0262208475919e1a362f675cfc0e7c10e905
+  version: 21a35fb16463dfb7c8eee579c65d995d95e64d1e
 - name: github.com/olivere/elastic
-  version: d8c80d884c60d6844d3042cf1697998f34c25e37
+  version: 787ebbb5a7600662bca364e4e8ca959f315e442f
+- name: github.com/pkg/errors
+  version: 01fa4104b9c248c8945d14d9f128454d5b28d595
 - name: github.com/prometheus/client_golang
-  version: 9f1ed1ed4a5f754c9b626e5cf8ec1ea7d622e017
+  version: 52437c81da6b127a9925d17eb3a382a2e5fd395e
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
@@ -119,7 +121,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 4402f4e5ea79ec15f3c574773b6a5198fbea215f
+  version: ebdfc6da46522d58825777cf1f90490a5b1ef1d8
   subpackages:
   - expfmt
   - model
@@ -129,7 +131,7 @@ imports:
 - name: github.com/prometheus/procfs
   version: abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
 - name: github.com/prometheus/prometheus
-  version: e2bb136f4eb24df85153d41f9798e0f194511d72
+  version: be4019065c943428e1ac88750aa364a7d9d6d1b3
   subpackages:
   - promql
   - retrieval
@@ -161,23 +163,23 @@ imports:
   subpackages:
   - zk
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+  version: 0aa62d5ddceb50dbcb909d790b5345affd3669b6
 - name: github.com/serialx/hashring
   version: 75d57fa264ad17fd929304dfdb02c8e278c5c01c
 - name: github.com/Shopify/sarama
-  version: 88a4afb3d18f13212477a63a78e3a57ac87830a9
+  version: 9bb4a68d57ff6f623363aa172f0a8297aa289ba7
 - name: github.com/Sirupsen/logrus
-  version: f3cfb454f4c209e6668c95216c4744b8fddb2356
+  version: a283a10442df8dc09befd873fab202bf8a253d6a
 - name: github.com/spf13/cast
-  version: 27b586b42e29bec072fe7379259cc719e1289da6
+  version: e31f36ffc91a2ba9ddb72a4b6a607ff9b3d3cb63
 - name: github.com/spf13/cobra
-  version: 6a8bd97bdb1fc0d08a83459940498ea49d3e8c93
+  version: f62e98d28ab7ad31d707ba837a966378465c7b57
 - name: github.com/spf13/jwalterweatherman
   version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
 - name: github.com/spf13/pflag
-  version: 367864438f1b1a3c7db4da06a2f55b144e6784e0
+  version: 1560c1005499d61b80f865c04d39ca7505bf7f0b
 - name: github.com/spf13/viper
-  version: c1ccc378a054ea8d4e38d8c67f6938d4760b53dd
+  version: b53595fb56a492ecef90ee0457595a999eb6ec15
 - name: github.com/supershabam/pipeline
   version: cda9b8b65a7f4fb0da5afdfaf816323e29945b25
 - name: github.com/supershabam/pipeliner
@@ -200,12 +202,12 @@ imports:
 - name: github.com/vaughan0/go-ini
   version: a98ad7ee00ec53921f08832bc06ecf7fd600e6a1
 - name: golang.org/x/net
-  version: b400c2eff1badec7022a8c8f5bea058b6315eed7
+  version: f6d211983832e1efcd77e80779fd5f1142741356
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/sys
-  version: 62bee037599929a6e9146f29d10dd5208c43507d
+  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
   subpackages:
   - unix
 - name: gopkg.in/fsnotify.v1
@@ -213,10 +215,10 @@ imports:
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/olivere/elastic.v3
-  version: d8c80d884c60d6844d3042cf1697998f34c25e37
+  version: 787ebbb5a7600662bca364e4e8ca959f315e442f
   subpackages:
   - backoff
   - uritemplates
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
-devImports: []
+  version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -90,3 +90,5 @@ import:
 - package: gopkg.in/fsnotify.v1
 - package: github.com/vaughan0/go-ini
 - package: github.com/dgrijalva/jwt-go
+- package: github.com/pkg/errors
+  version: ~0.7.0


### PR DESCRIPTION
`github.com/pkg/errors` was missing and lockfile was out of date with yaml.

Ran

```
glide add github.com/pkg/errors
glide update
```
