### PR TITLE
scraper: removes pools configuration for zkroot

### DIFF
--- a/cmd/scraper.go
+++ b/cmd/scraper.go
@@ -21,89 +21,87 @@ import (
 // Scraper handles parsing the command line options, initializes, and starts the
 // scraper service accordingling.  It is the entry point for the scraper
 // service.
-var Scraper = &cobra.Command{
-	Use:   "scraper",
-	Short: "runs a scraper agent to collect metrics into kafka",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		log.SetLevel(log.DebugLevel)
-		myID := uuid.NewV4()
-		// bind pflags to viper so they are settable by env variables
-		cmd.Flags().VisitAll(func(f *pflag.Flag) {
-			viper.BindPFlag(f.Name, f)
-		})
+func Scraper() *cobra.Command {
+	scraper := &cobra.Command{
+		Use:   "scraper",
+		Short: "runs a scraper agent to collect metrics into kafka",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.SetLevel(log.DebugLevel)
+			myID := uuid.NewV4()
+			// bind pflags to viper so they are settable by env variables
+			cmd.Flags().VisitAll(func(f *pflag.Flag) {
+				viper.BindPFlag(f.Name, f)
+			})
 
-		// set up zk connection
-		zkconn, _, err := zk.Connect(strings.Split(viper.GetString("zk-servers"), ","), viper.GetDuration("zk-timeout"))
-		if err != nil {
-			return err
-		}
+			// set up zk connection
+			zkconn, _, err := zk.Connect(strings.Split(viper.GetString("zk-servers"), ","), viper.GetDuration("zk-timeout"))
+			if err != nil {
+				return err
+			}
 
-		// get targets from watching a zookeeper directory
-		zkt, err := zookeeper.NewTargeter(&zookeeper.TargeterConfig{
-			Conn: zkconn,
-			Root: viper.GetString("zk-root"),
-			Pool: viper.GetString("pool"),
-		})
-		if err != nil {
-			return err
-		}
+			// get targets from watching a zookeeper directory
+			zkt, err := zookeeper.NewTargeter(&zookeeper.TargeterConfig{
+				Conn: zkconn,
+				Root: viper.GetString("zk-root"),
+			})
+			if err != nil {
+				return err
+			}
 
-		// get a channel of online scrapers (including yourself)
-		p, err := zookeeper.NewPool(&zookeeper.PoolConfig{
-			ID:   myID.String(),
-			Conn: zkconn,
-			Root: viper.GetString("zk-root"),
-			Pool: viper.GetString("pool"),
-		})
-		if err != nil {
-			return err
-		}
+			// get a channel of online scrapers (including yourself)
+			p, err := zookeeper.NewPool(&zookeeper.PoolConfig{
+				ID:   myID.String(),
+				Conn: zkconn,
+				Root: viper.GetString("zk-root"),
+			})
+			if err != nil {
+				return err
+			}
 
-		// filter targeter based on a consistent hash with available nodes in the pool
-		ft := scraper.NewConsistentHashTargeter(&scraper.ConsistentHashTargeterConfig{
-			Targeter: zkt,
-			Pool:     p,
-			ID:       myID.String(),
-		})
+			// filter targeter based on a consistent hash with available nodes in the pool
+			ft := scraper.NewConsistentHashTargeter(&scraper.ConsistentHashTargeterConfig{
+				Targeter: zkt,
+				Pool:     p,
+				ID:       myID.String(),
+			})
 
-		// create upstream kafka writer to receive data
-		w, err := kafka.NewWriter(&kafka.WriterConfig{
-			ClientID: viper.GetString("kafka-client-id"),
-			Topic:    viper.GetString("kafka-topic"),
-			Addrs:    strings.Split(viper.GetString("kafka-addrs"), ","),
-		})
-		if err != nil {
-			return err
-		}
+			// create upstream kafka writer to receive data
+			w, err := kafka.NewWriter(&kafka.WriterConfig{
+				ClientID: viper.GetString("kafka-client-id"),
+				Topic:    viper.GetString("kafka-topic"),
+				Addrs:    strings.Split(viper.GetString("kafka-addrs"), ","),
+			})
+			if err != nil {
+				return err
+			}
 
-		// create the scraper which orchestrates scraping targets and writing their
-		// results to the upstream
-		s := scraper.NewScraper(&scraper.Config{
-			Targeter: ft,
-			Writer:   w,
-		})
-		// prometheus.MustRegister(s)
-		go func() {
-			http.Handle("/metrics", prometheus.Handler())
-			http.ListenAndServe(":8080", nil)
-		}()
-		log.Info("running...")
-		err = s.Run()
-		if err != nil {
-			return err
-		}
+			// create the scraper which orchestrates scraping targets and writing their
+			// results to the upstream
+			s := scraper.NewScraper(&scraper.Config{
+				Targeter: ft,
+				Writer:   w,
+			})
+			// prometheus.MustRegister(s)
+			go func() {
+				http.Handle("/metrics", prometheus.Handler())
+				http.ListenAndServe(":8080", nil)
+			}()
+			log.Info("running...")
+			err = s.Run()
+			if err != nil {
+				return err
+			}
 
-		return nil
-	},
-}
+			return nil
+		},
+	}
 
-func init() {
-	Scraper.Flags().Duration("zk-timeout", time.Second*10, "zookeeper timeout")
-	Scraper.Flags().String("zk-servers", "", "comma-separated list of zookeeper servers")
-	// TODO parse zk-root from zookeeper server uri e.g. server1,server2:2181/root/path
-	Scraper.Flags().String("zk-root", "/vulcan", "zookeeper path under which jobs are stored")
-	Scraper.Flags().String("kafka-topic", "vulcan", "kafka topic to write to")
-	Scraper.Flags().String("kafka-addrs", "", "one.example.com:9092,two.example.com:9092")
-	Scraper.Flags().String("kafka-client-id", "vulcan-scraper", "set the kafka client id")
-	Scraper.Flags().String("pool", "default", "name of the scraper pool to join")
+	scraper.Flags().Duration("zk-timeout", time.Second*10, "zookeeper timeout")
+	scraper.Flags().String("zk-servers", "", "comma-separated list of zookeeper servers")
+	scraper.Flags().String("zk-root", "/vulcan", "zookeeper path under which jobs are stored")
+	scraper.Flags().String("kafka-topic", "vulcan", "kafka topic to write to")
+	scraper.Flags().String("kafka-addrs", "", "one.example.com:9092,two.example.com:9092")
+	scraper.Flags().String("kafka-client-id", "vulcan-scraper", "set the kafka client id")
+
+	return scraper
 }

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	vulcan.AddCommand(cmd.Indexer())
 	vulcan.AddCommand(cmd.Ingester)
 	vulcan.AddCommand(cmd.Querier)
-	vulcan.AddCommand(cmd.Scraper)
+	vulcan.AddCommand(cmd.Scraper())
 
 	vulcan.AddCommand(cmd.Job())
 	vulcan.AddCommand(cmd.Version(hash, version))

--- a/zookeeper/pool.go
+++ b/zookeeper/pool.go
@@ -15,7 +15,6 @@ type Pool struct {
 	id   string
 	conn Client
 	path string
-	pool string
 	done chan struct{}
 	out  chan []string
 	once sync.Once
@@ -26,8 +25,7 @@ func NewPool(config *PoolConfig) (*Pool, error) {
 	p := &Pool{
 		id:   config.ID,
 		conn: config.Conn,
-		path: path.Join(config.Root, "scraper", config.Pool, "scrapers"),
-		pool: config.Pool,
+		path: path.Join(config.Root, "scraper", "scrapers"),
 		done: make(chan struct{}),
 		out:  make(chan []string),
 	}
@@ -40,7 +38,6 @@ type PoolConfig struct {
 	ID   string
 	Conn Client
 	Root string
-	Pool string
 }
 
 func (p *Pool) run() {
@@ -48,7 +45,6 @@ func (p *Pool) run() {
 	mypath := path.Join(p.path, p.id)
 	mylog := log.WithFields(log.Fields{
 		"path": p.path,
-		"pool": p.pool,
 		"id":   p.id,
 	})
 	mylog.Info("registering self in zookeeper")

--- a/zookeeper/pool_test.go
+++ b/zookeeper/pool_test.go
@@ -49,7 +49,6 @@ func TestPoolRun(t *testing.T) {
 			id:   "default-test",
 			conn: c.Mock,
 			path: "/vulcan/test/scrapers",
-			pool: "default",
 			done: make(chan struct{}),
 			out:  make(chan []string),
 		}

--- a/zookeeper/targeter.go
+++ b/zookeeper/targeter.go
@@ -25,7 +25,7 @@ type Targeter struct {
 func NewTargeter(config *TargeterConfig) (*Targeter, error) {
 	t := &Targeter{
 		conn: config.Conn,
-		path: path.Join(config.Root, "scraper", config.Pool, "jobs"),
+		path: path.Join(config.Root, "scraper", "jobs"),
 
 		children: map[string]*PathTargeter{},
 		out:      make(chan scraper.Job),
@@ -38,7 +38,6 @@ func NewTargeter(config *TargeterConfig) (*Targeter, error) {
 type TargeterConfig struct {
 	Conn Client
 	Root string
-	Pool string
 }
 
 // Targets implements scraper.Targeter interface.


### PR DESCRIPTION
zkroot allows us to namespace different sets of scrapers on a
shared zookeeper. Pool/cluster is a redundant configuration
that adds complexity. The pool/cluster was removed from the job
subcommand but not from the scraper. This fixes the scraper
to use the same zookeeper pathing strategy as job.
