### PR TITLE
scraper: removed unnecessary default case in run

### DIFF
--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -61,8 +61,6 @@ func (s *Scraper) Run() {
 
 		case <-s.done:
 			return
-
-		default:
 		}
 	}
 }


### PR DESCRIPTION
fixes cpu hog issue.
