### PR TITLE
querier: implements metadata API

### DIFF
--- a/storage/elasticsearch/integration_test.go
+++ b/storage/elasticsearch/integration_test.go
@@ -325,3 +325,44 @@ func TestResolve(t *testing.T) {
 		}
 	}
 }
+
+func TestValues(t *testing.T) {
+	err := down()
+	if err != nil {
+		t.Error(err)
+	}
+	err = up()
+	if err != nil {
+		t.Error(err)
+	}
+	r, err := elasticsearch.NewResolver(&elasticsearch.ResolverConfig{
+		URL:   *es,
+		Sniff: false,
+		Index: "vulcan-integration",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	tests := []struct {
+		Field  string
+		Values []string
+	}{
+		{
+			Field:  "__name__",
+			Values: []string{"metric_1"},
+		},
+		{
+			Field:  "l",
+			Values: []string{"value-one", "value-two", "value-three"},
+		},
+	}
+	for _, test := range tests {
+		res, err := r.Values(test.Field)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(res) != len(test.Values) {
+			t.Errorf("expected %d value for %s values but got %d", len(test.Values), test.Field, len(res))
+		}
+	}
+}

--- a/storage/elasticsearch/integration_test.go
+++ b/storage/elasticsearch/integration_test.go
@@ -182,7 +182,7 @@ func upEntries() error {
 	return nil
 }
 
-func TestResolver(t *testing.T) {
+func TestResolve(t *testing.T) {
 	err := down()
 	if err != nil {
 		t.Error(err)

--- a/storage/elasticsearch/resolver.go
+++ b/storage/elasticsearch/resolver.go
@@ -94,7 +94,7 @@ func (r *Resolver) Resolve(matches []*storage.Match) ([]*bus.Metric, error) {
 // a query should use in a filter.
 func (r *Resolver) Values(field string) ([]string, error) {
 	aggr := elastic.NewTermsAggregation().
-		Field(convert.ESEscape(field)).
+		Field(fmt.Sprintf("%s.raw", convert.ESEscape(field))).
 		Size(10000) // arbitrarily large
 	res, err := r.client.Search().
 		Index(r.index).

--- a/storage/elasticsearch/resolver.go
+++ b/storage/elasticsearch/resolver.go
@@ -17,6 +17,7 @@ package elasticsearch
 import (
 	"fmt"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/digitalocean/vulcan/bus"
 	"github.com/digitalocean/vulcan/convert"
 	"github.com/digitalocean/vulcan/storage"
@@ -51,7 +52,7 @@ func NewResolver(config *ResolverConfig) (*Resolver, error) {
 }
 
 // Resolve implements the storage.Resolver interface.
-func (mr *Resolver) Resolve(matches []*storage.Match) ([]*bus.Metric, error) {
+func (r *Resolver) Resolve(matches []*storage.Match) ([]*bus.Metric, error) {
 	q := elastic.NewBoolQuery()
 	for _, m := range matches {
 		switch m.Type {
@@ -67,8 +68,8 @@ func (mr *Resolver) Resolve(matches []*storage.Match) ([]*bus.Metric, error) {
 			return []*bus.Metric{}, fmt.Errorf("unhandled match type")
 		}
 	}
-	sr, err := mr.client.Search().
-		Index(mr.index).
+	sr, err := r.client.Search().
+		Index(r.index).
 		NoFields().         // only want the _id
 		Sort("_doc", true). // sort by _doc since it is most efficient to return large results https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
 		Query(q).
@@ -86,4 +87,37 @@ func (mr *Resolver) Resolve(matches []*storage.Match) ([]*bus.Metric, error) {
 		ml = append(ml, m)
 	}
 	return ml, nil
+}
+
+// Values returns the unique values for a given metric field. This allows
+// vulcan to provide hinting on what metrics exist or what label values
+// a query should use in a filter.
+func (r *Resolver) Values(field string) ([]string, error) {
+	aggr := elastic.NewTermsAggregation().
+		Field(convert.ESEscape(field)).
+		Size(10000) // arbitrarily large
+	res, err := r.client.Search().
+		Index(r.index).
+		Query(elastic.NewMatchAllQuery()).
+		SearchType("count").
+		Aggregation("label_values", aggr).
+		Do()
+	if err != nil {
+		return []string{}, err
+	}
+	itms, found := res.Aggregations.Terms("label_values")
+	if !found {
+		return []string{}, nil
+	}
+	values := []string{}
+	for _, bucket := range itms.Buckets {
+		if key, ok := bucket.Key.(string); ok {
+			values = append(values, key)
+			continue
+		}
+		log.WithFields(log.Fields{
+			"field": field,
+		}).Warning("unable to cast result bucket key to string")
+	}
+	return values, nil
 }

--- a/storage/resolver.go
+++ b/storage/resolver.go
@@ -39,9 +39,11 @@ type Match struct {
 	Value string
 }
 
-// Resolver is a interface that wraps the Resolve method.
+// Resolver is a interface that wraps a database that can answer questions
+// on what metrics exist.
 type Resolver interface {
 	// Resolve makes a query using the provided key value pairs of query
 	// params and transforms the results to Vulcan Metric type.
 	Resolve([]*Match) ([]*bus.Metric, error)
+	Values(field string) ([]string, error)
 }


### PR DESCRIPTION
resolves https://github.com/digitalocean/vulcan/issues/37

This allows the grafana and the `/graph` page to query what metrics exist in vulcan to help the user write queries.