### PR TITLE
Feature/forwarder

### DIFF
--- a/bus/writer.go
+++ b/bus/writer.go
@@ -18,5 +18,5 @@ import "github.com/prometheus/prometheus/storage/remote"
 
 // Writer is an interface that wraps the Write method to a message bus.
 type Writer interface {
-	Write(string, *remote.WriteRequest) error
+	Write(key string, req *remote.WriteRequest) error
 }

--- a/bus/writer.go
+++ b/bus/writer.go
@@ -1,0 +1,22 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bus
+
+import "github.com/prometheus/prometheus/storage/remote"
+
+// Writer is an interface that wraps the Write method to a message bus.
+type Writer interface {
+	Write(string, *remote.WriteRequest) error
+}

--- a/bus/writer_mock.go
+++ b/bus/writer_mock.go
@@ -1,0 +1,96 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bus
+
+import (
+	"sort"
+
+	"github.com/prometheus/prometheus/storage/remote"
+)
+
+// MOCKWRITEERR is a constant for the error string for a returned MockWriter error.
+const MOCKWRITEERR = `WRITEERR`
+
+// MockWriteArgs is an object that represents the arguments passed to the Write function.
+type MockWriteArgs struct {
+	Key          string
+	WriteRequest *remote.WriteRequest
+}
+
+// MockWriter is an object respresents a fake message bus writer.
+type MockWriter struct {
+	WErr       error
+	WriteCount int
+	Args       []*MockWriteArgs
+}
+
+// NewMockWriter returns an instance of MockWriter.
+func NewMockWriter() *MockWriter {
+	return &MockWriter{
+		Args: make([]*MockWriteArgs, 0),
+	}
+}
+
+// Write implements bus.Writer.
+func (w *MockWriter) Write(k string, wr *remote.WriteRequest) error {
+	w.Args = append(w.Args, &MockWriteArgs{Key: k, WriteRequest: wr})
+
+	if w.WErr == nil {
+		w.WriteCount++
+		return nil
+	}
+
+	return w.WErr
+}
+
+type argsSorter struct {
+	args []*MockWriteArgs
+	by   func(a1, a2 *MockWriteArgs) bool
+}
+
+// Len implements sort.Sort interface.
+func (s *argsSorter) Len() int { return len(s.args) }
+
+// Swap implements sort.Sort interface.
+func (s *argsSorter) Swap(i, j int) {
+	s.args[i], s.args[j] = s.args[j], s.args[i]
+}
+
+// Less implements sort.Sort interface.
+func (s *argsSorter) Less(i, j int) bool {
+	return s.by(s.args[i], s.args[j])
+}
+
+// ByMockWriterArgs is a less function that defines how to order a MockWriteArgs.
+type ByMockWriterArgs func(a1, a2 *MockWriteArgs) bool
+
+// Sort sorts the MockWriteArgs slice by the criteria defined in the By function.
+func (by ByMockWriterArgs) Sort(args []*MockWriteArgs) {
+	s := &argsSorter{args: args, by: by}
+	sort.Sort(s)
+}
+
+// Sorting types
+
+// WriteArgKey allows sorting by the Key associated of MockWriteArgs.
+func WriteArgKey(a1, a2 *MockWriteArgs) bool {
+	return a1.Key < a2.Key
+}
+
+// WriteArgTimeSeriesLength allows sorting by the length of the Timeseries slice of
+// the WriteRequest associated with MockWriteArgs.
+func WriteArgTimeSeriesLength(a1, a2 *MockWriteArgs) bool {
+	return len(a1.WriteRequest.Timeseries) < len(a2.WriteRequest.Timeseries)
+}

--- a/cmd/forwarder.go
+++ b/cmd/forwarder.go
@@ -1,0 +1,76 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net"
+	"strings"
+
+	"google.golang.org/grpc"
+
+	"github.com/digitalocean/vulcan/forwarder"
+	"github.com/digitalocean/vulcan/kafka"
+
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// Forwarder handles parsing the command line options, initializes, and starts the
+// forwarder service accordingling.  It is the entry point for the forwarder
+// service.
+func Forwarder() *cobra.Command {
+	f := &cobra.Command{
+		Use:   "forwarder",
+		Short: "forwards metric received from promotheus to message bus",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Flags().VisitAll(func(f *pflag.Flag) {
+				viper.BindPFlag(f.Name, f)
+			})
+
+			// create upstream kafka writer to receive data
+			w, err := kafka.NewWriter(&kafka.WriterConfig{
+				ClientID: viper.GetString("kafka-client-id"),
+				Topic:    viper.GetString("kafka-topic"),
+				Addrs:    strings.Split(viper.GetString("kafka-addrs"), ","),
+			})
+			if err != nil {
+				return err
+			}
+
+			bw := forwarder.NewForwarder(&forwarder.Config{Writer: w})
+
+			d := forwarder.NewDecompressor()
+
+			lis, err := net.Listen("tcp", viper.GetString("address"))
+			if err != nil {
+				return err
+			}
+
+			server := grpc.NewServer(grpc.RPCDecompressor(d))
+			remote.RegisterWriteServer(server, bw)
+
+			return server.Serve(lis)
+		},
+	}
+
+	f.Flags().String("address", ":8888", "grpc server listening address")
+	f.Flags().String("kafka-topic", "vulcan", "kafka topic to write to")
+	f.Flags().String("kafka-addrs", "", "one.example.com:9092,two.example.com:9092")
+	f.Flags().String("kafka-client-id", "vulcan-forwarder", "set the kafka client id")
+
+	return f
+}

--- a/cmd/forwarder.go
+++ b/cmd/forwarder.go
@@ -36,7 +36,7 @@ import (
 func Forwarder() *cobra.Command {
 	f := &cobra.Command{
 		Use:   "forwarder",
-		Short: "forwards metric received from promotheus to message bus",
+		Short: "forwards metric received from prometheus to message bus",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.SetLevel(log.DebugLevel)
 

--- a/forwarder/rpc_decompressor.go
+++ b/forwarder/rpc_decompressor.go
@@ -1,0 +1,42 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forwarder
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/golang/snappy"
+)
+
+// Decompressor represents object that implements a GRPC Compressor interface.
+// Currently only supports Snappy decompression.
+type Decompressor struct{}
+
+// NewDecompressor returns a new Decompressor.
+func NewDecompressor() *Decompressor {
+	return &Decompressor{}
+}
+
+// Do implements GRPC Compressor interface.
+func (d *Decompressor) Do(r io.Reader) ([]byte, error) {
+	sr := snappy.NewReader(r)
+	return ioutil.ReadAll(sr)
+}
+
+// Type implements GRPC Compressor interface.
+func (d *Decompressor) Type() string {
+	return "snappy"
+}

--- a/forwarder/rpc_decompressor.go
+++ b/forwarder/rpc_decompressor.go
@@ -18,12 +18,16 @@ import (
 	"io"
 	"io/ioutil"
 
+	"google.golang.org/grpc"
+
 	"github.com/golang/snappy"
 )
 
 // Decompressor represents object that implements a GRPC Compressor interface.
 // Currently only supports Snappy decompression.
 type Decompressor struct{}
+
+var _ grpc.Decompressor = &Decompressor{}
 
 // NewDecompressor returns a new Decompressor.
 func NewDecompressor() *Decompressor {

--- a/forwarder/writer.go
+++ b/forwarder/writer.go
@@ -1,0 +1,130 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forwarder
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	"github.com/digitalocean/vulcan/bus"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/remote"
+)
+
+// Forwarder represents an object that accepts metrics from Prometheus.
+// Metrics are grouped by target instance and written to the configured
+// Vulcan message bus.
+type Forwarder struct {
+	writer bus.Writer
+}
+
+// Config represents the configuration for a Forwarder.
+type Config struct {
+	Writer bus.Writer
+}
+
+// NewForwarder creates a new instance of Forwarder.
+func NewForwarder(config *Config) *Forwarder {
+	return &Forwarder{
+		writer: config.Writer,
+	}
+}
+
+// Write implements remote.WriteClient interface.
+func (f *Forwarder) Write(ctx context.Context, req *remote.WriteRequest) (*remote.WriteResponse, error) {
+	var (
+		toWrite = map[string]*remote.WriteRequest{}
+		ll      = log.WithFields(log.Fields{"source": "forwarder.Write"})
+	)
+	// Batch time series data by instance, fallback on address.
+	for _, ts := range req.Timeseries {
+		key, err := getKey(ts)
+		if err != nil {
+			ll.WithFields(log.Fields{
+				"timeseries": ts,
+			}).WithError(err).Error("could not formulate key from labels")
+
+			continue
+		}
+
+		if _, ok := toWrite[key]; !ok {
+			toWrite[key] = &remote.WriteRequest{
+				Timeseries: []*remote.TimeSeries{ts},
+			}
+		} else {
+			toWrite[key].Timeseries = append(toWrite[key].Timeseries, ts)
+		}
+	}
+
+	// Write each batch to the Vulcan bus.
+	for key, wr := range toWrite {
+		ll.WithFields(log.Fields{
+			"key":              key,
+			"timeseries_count": len(wr.Timeseries),
+		}).Info("writing to bus")
+
+		if err := f.writer.Write(key, wr); err != nil {
+			log.WithFields(log.Fields{
+				"key": key,
+			}).WithError(err).Error("failed to write to bus")
+
+			continue
+		}
+	}
+
+	return &remote.WriteResponse{}, nil
+}
+
+// getKey formulates the instance key based on Prometheus metric labels.
+func getKey(ts *remote.TimeSeries) (string, error) {
+	var (
+		jobName, inst string
+		instFound     bool
+	)
+
+	for _, l := range ts.Labels {
+		if jobName != "" && instFound {
+			break
+		}
+
+		switch l.Name {
+		case model.JobLabel:
+			jobName = l.Value
+
+		case model.InstanceLabel:
+			inst = l.Value
+			instFound = true
+
+		case model.AddressLabel:
+			if inst == "" {
+				inst = l.Value
+			}
+		}
+	}
+
+	if jobName == "" {
+		return "", errors.New("missing job label")
+	}
+
+	if inst == "" {
+		return "", errors.New("missing instance label and address label")
+	}
+
+	return fmt.Sprintf("%s-%s", jobName, inst), nil
+}

--- a/forwarder/writer_test.go
+++ b/forwarder/writer_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/prometheus/prometheus/storage/remote"
 )
 
-func TestGetKey(t *testing.T) {
+func getKeyHappyPath(t *testing.T) {
 	var happyPathTests = []struct {
 		desc     string
 		arg      *remote.TimeSeries
@@ -136,7 +136,9 @@ func TestGetKey(t *testing.T) {
 			)
 		}
 	}
+}
 
+func getKeyNegative(t *testing.T) {
 	var negativeTests = []struct {
 		desc string
 		arg  *remote.TimeSeries
@@ -188,6 +190,26 @@ func TestGetKey(t *testing.T) {
 		if _, err := getKey(test.arg); err == nil {
 			t.Errorf("getKey(%v) => expected an error but got nil", test.arg)
 		}
+	}
+}
+
+func TestGetKey(t *testing.T) {
+	var tests = []struct {
+		name     string
+		testFunc func(*testing.T)
+	}{
+		{
+			name:     "happy",
+			testFunc: getKeyHappyPath,
+		},
+		{
+			name:     "neg",
+			testFunc: getKeyNegative,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, test.testFunc)
 	}
 }
 

--- a/forwarder/writer_test.go
+++ b/forwarder/writer_test.go
@@ -1,0 +1,874 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forwarder
+
+import (
+	"reflect"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/digitalocean/vulcan/bus"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/remote"
+)
+
+func TestGetKey(t *testing.T) {
+	var happyPathTests = []struct {
+		desc     string
+		arg      *remote.TimeSeries
+		expected string
+	}{
+		{
+			desc: "all expected labels present in beginning of labels slice",
+			arg: &remote.TimeSeries{
+				Labels: []*remote.LabelPair{
+					&remote.LabelPair{Name: model.JobLabel, Value: "foobar"},
+					&remote.LabelPair{Name: model.AddressLabel, Value: "sammy.example.com:9999"},
+					&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+					&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+					&remote.LabelPair{Name: model.MetricNameLabel, Value: "fake"},
+					&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+				},
+			},
+			expected: "foobar-inst8888",
+		},
+		{
+			desc: "all expected labels present in end of labels slice",
+			arg: &remote.TimeSeries{
+				Labels: []*remote.LabelPair{
+					&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+					&remote.LabelPair{Name: model.MetricNameLabel, Value: "fake"},
+					&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+					&remote.LabelPair{Name: model.JobLabel, Value: "foobar"},
+					&remote.LabelPair{Name: model.AddressLabel, Value: "sammy.example.com:9999"},
+					&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+				},
+			},
+			expected: "foobar-inst8888",
+		},
+		{
+			desc: "only job and address labels present in end of labels slice",
+			arg: &remote.TimeSeries{
+				Labels: []*remote.LabelPair{
+					&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+					&remote.LabelPair{Name: model.MetricNameLabel, Value: "fake"},
+					&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+					&remote.LabelPair{Name: model.JobLabel, Value: "foobar"},
+					&remote.LabelPair{Name: model.AddressLabel, Value: "sammy.example.com:9999"},
+				},
+			},
+			expected: "foobar-sammy.example.com:9999",
+		},
+		{
+			desc: "only job and address labels present in beginning of labels slice",
+			arg: &remote.TimeSeries{
+				Labels: []*remote.LabelPair{
+					&remote.LabelPair{Name: model.JobLabel, Value: "foobar"},
+					&remote.LabelPair{Name: model.AddressLabel, Value: "sammy.example.com:9999"},
+					&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+					&remote.LabelPair{Name: model.MetricNameLabel, Value: "fake"},
+					&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+				},
+			},
+			expected: "foobar-sammy.example.com:9999",
+		},
+		{
+			desc: "all expected labels present, but instance label before address label",
+			arg: &remote.TimeSeries{
+				Labels: []*remote.LabelPair{
+					&remote.LabelPair{Name: model.JobLabel, Value: "foobar"},
+					&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+					&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+					&remote.LabelPair{Name: model.MetricNameLabel, Value: "fake"},
+					&remote.LabelPair{Name: model.AddressLabel, Value: "sammy.example.com:9999"},
+					&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+				},
+			},
+			expected: "foobar-inst8888",
+		},
+		{
+			desc: "only job and instance labels",
+			arg: &remote.TimeSeries{
+				Labels: []*remote.LabelPair{
+					&remote.LabelPair{Name: model.JobLabel, Value: "foobar"},
+					&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+					&remote.LabelPair{Name: model.MetricNameLabel, Value: "fake"},
+					&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+					&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+				},
+			},
+			expected: "foobar-inst8888",
+		},
+	}
+
+	for i, test := range happyPathTests {
+		t.Logf("happy path tests %d: %q", i, test.desc)
+
+		got, err := getKey(test.arg)
+		if err != nil {
+			t.Fatalf(
+				"getKey(%v) => error: %v; expected nil errors",
+				test.arg,
+				err,
+			)
+		}
+
+		if got != test.expected {
+			t.Errorf(
+				"getKey(%v) => %q; expected %q",
+				test.arg,
+				got,
+				test.expected,
+			)
+		}
+	}
+
+	var negativeTests = []struct {
+		desc string
+		arg  *remote.TimeSeries
+	}{
+		{
+			desc: "no job label",
+			arg: &remote.TimeSeries{
+				Labels: []*remote.LabelPair{
+					&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+					&remote.LabelPair{Name: model.MetricNameLabel, Value: "fake"},
+					&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+					&remote.LabelPair{Name: model.AddressLabel, Value: "sammy.example.com:9999"},
+					&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+				},
+			},
+		},
+		{
+			desc: "no address and instance label",
+			arg: &remote.TimeSeries{
+				Labels: []*remote.LabelPair{
+					&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+					&remote.LabelPair{Name: model.MetricNameLabel, Value: "fake"},
+					&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+					&remote.LabelPair{Name: model.JobLabel, Value: "foobar"},
+				},
+			},
+		},
+		{
+			desc: "no address, job, and instance label",
+			arg: &remote.TimeSeries{
+				Labels: []*remote.LabelPair{
+					&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+					&remote.LabelPair{Name: model.MetricNameLabel, Value: "fake"},
+					&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+				},
+			},
+		},
+		{
+			desc: "no labels",
+			arg: &remote.TimeSeries{
+				Labels: []*remote.LabelPair{},
+			},
+		},
+	}
+
+	for i, test := range negativeTests {
+		t.Logf("negative test %d: %q", i, test.desc)
+
+		if _, err := getKey(test.arg); err == nil {
+			t.Errorf("getKey(%v) => expected an error but got nil", test.arg)
+		}
+	}
+}
+
+func TestForwarderWrite(t *testing.T) {
+	var integrationTests = []struct {
+		desc               string
+		arg                *remote.WriteRequest
+		expectedWriteCount int
+		expectedWriteArgs  []*bus.MockWriteArgs
+	}{
+		{
+			desc: "3 TimeSeries metrics, 3 unique keys",
+			arg: &remote.WriteRequest{
+				Timeseries: []*remote.TimeSeries{
+					// job a
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.AddressLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_a",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(1.34566),
+								TimestampMs: int64(64657774758),
+							},
+						},
+					},
+					// job b
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:8888",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_b",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(8.099498),
+								TimestampMs: int64(783474387548),
+							},
+						},
+					},
+					// job c
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.AddressLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_c",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(2.34566),
+								TimestampMs: int64(649957774758),
+							},
+						},
+					},
+				},
+			},
+			expectedWriteCount: 3,
+			expectedWriteArgs: []*bus.MockWriteArgs{
+				&bus.MockWriteArgs{
+					Key: "scrape_test_a-sammy.example.com:9999",
+					WriteRequest: &remote.WriteRequest{
+						Timeseries: []*remote.TimeSeries{
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.AddressLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_a",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(1.34566),
+										TimestampMs: int64(64657774758),
+									},
+								},
+							},
+						},
+					},
+				},
+				&bus.MockWriteArgs{
+					Key: "scrape_test_b-sammy.example.com:8888",
+					WriteRequest: &remote.WriteRequest{
+						Timeseries: []*remote.TimeSeries{
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:8888",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_b",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(8.099498),
+										TimestampMs: int64(783474387548),
+									},
+								},
+							},
+						},
+					},
+				},
+				&bus.MockWriteArgs{
+					Key: "scrape_test_c-sammy.example.com:9999",
+					WriteRequest: &remote.WriteRequest{
+						Timeseries: []*remote.TimeSeries{
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.AddressLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_c",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(2.34566),
+										TimestampMs: int64(649957774758),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			desc: "5 TimeSeries metrics, 2 unique keys",
+			arg: &remote.WriteRequest{
+				Timeseries: []*remote.TimeSeries{
+					// job a
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.AddressLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_a",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(1.34566),
+								TimestampMs: int64(64657774758),
+							},
+						},
+					},
+					// job b
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:8888",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_b",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(8.099498),
+								TimestampMs: int64(783474387548),
+							},
+						},
+					},
+					// job a
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.AddressLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_a",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(9090.00000),
+								TimestampMs: int64(47834793879875),
+							},
+						},
+					},
+					// job a
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.AddressLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_a",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(1.34335),
+								TimestampMs: int64(4356466256),
+							},
+							&remote.Sample{
+								Value:       float64(1455.454646),
+								TimestampMs: int64(4597568475847),
+							},
+						},
+					},
+					// job b
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:8888",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_b",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(8.099498),
+								TimestampMs: int64(889848577448),
+							},
+						},
+					},
+				},
+			},
+			expectedWriteCount: 2,
+			expectedWriteArgs: []*bus.MockWriteArgs{
+				&bus.MockWriteArgs{
+					Key: "scrape_test_a-sammy.example.com:9999",
+					WriteRequest: &remote.WriteRequest{
+						Timeseries: []*remote.TimeSeries{
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.AddressLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_a",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(1.34566),
+										TimestampMs: int64(64657774758),
+									},
+								},
+							},
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.AddressLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_a",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(9090.00000),
+										TimestampMs: int64(47834793879875),
+									},
+								},
+							},
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.AddressLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_a",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(1.34335),
+										TimestampMs: int64(4356466256),
+									},
+									&remote.Sample{
+										Value:       float64(1455.454646),
+										TimestampMs: int64(4597568475847),
+									},
+								},
+							},
+						},
+					},
+				},
+				&bus.MockWriteArgs{
+					Key: "scrape_test_b-sammy.example.com:8888",
+					WriteRequest: &remote.WriteRequest{
+						Timeseries: []*remote.TimeSeries{
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:8888",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_b",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(8.099498),
+										TimestampMs: int64(783474387548),
+									},
+								},
+							},
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:8888",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_b",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(8.099498),
+										TimestampMs: int64(889848577448),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			desc: "5 TimeSeries metrics, 1 unique key",
+			arg: &remote.WriteRequest{
+				Timeseries: []*remote.TimeSeries{
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.AddressLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_a",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(1.34566),
+								TimestampMs: int64(64657774758),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_a",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(8.099498),
+								TimestampMs: int64(783474387548),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.AddressLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_a",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(9090.00000),
+								TimestampMs: int64(47834793879875),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.AddressLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_a",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(1.34335),
+								TimestampMs: int64(4356466256),
+							},
+							&remote.Sample{
+								Value:       float64(1455.454646),
+								TimestampMs: int64(4597568475847),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{
+								Name:  model.InstanceLabel,
+								Value: "sammy.example.com:9999",
+							},
+							&remote.LabelPair{
+								Name:  model.JobLabel,
+								Value: "scrape_test_a",
+							},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(8.099498),
+								TimestampMs: int64(889848577448),
+							},
+						},
+					},
+				},
+			},
+			expectedWriteCount: 1,
+			expectedWriteArgs: []*bus.MockWriteArgs{
+				&bus.MockWriteArgs{
+					Key: "scrape_test_a-sammy.example.com:9999",
+					WriteRequest: &remote.WriteRequest{
+						Timeseries: []*remote.TimeSeries{
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.AddressLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_a",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(1.34566),
+										TimestampMs: int64(64657774758),
+									},
+								},
+							},
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_a",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(8.099498),
+										TimestampMs: int64(783474387548),
+									},
+								},
+							},
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.AddressLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_a",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(9090.00000),
+										TimestampMs: int64(47834793879875),
+									},
+								},
+							},
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.AddressLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_a",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(1.34335),
+										TimestampMs: int64(4356466256),
+									},
+									&remote.Sample{
+										Value:       float64(1455.454646),
+										TimestampMs: int64(4597568475847),
+									},
+								},
+							},
+							&remote.TimeSeries{
+								Labels: []*remote.LabelPair{
+									&remote.LabelPair{
+										Name:  model.InstanceLabel,
+										Value: "sammy.example.com:9999",
+									},
+									&remote.LabelPair{
+										Name:  model.JobLabel,
+										Value: "scrape_test_a",
+									},
+								},
+								Samples: []*remote.Sample{
+									&remote.Sample{
+										Value:       float64(8.099498),
+										TimestampMs: int64(889848577448),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			desc: "no timeseries data in WriteRequest",
+			arg: &remote.WriteRequest{
+				Timeseries: []*remote.TimeSeries{},
+			},
+			expectedWriteCount: 0,
+			expectedWriteArgs:  make([]*bus.MockWriteArgs, 0),
+		},
+	}
+
+	for i, test := range integrationTests {
+		t.Logf("integration test %d: %q", i, test.desc)
+
+		mw := bus.NewMockWriter()
+		f := NewForwarder(&Config{Writer: mw})
+
+		// Not using any of the returned values currently
+		_, _ = f.Write(context.Background(), test.arg)
+
+		if mw.WriteCount != test.expectedWriteCount {
+			t.Errorf(
+				"Forwarder.Write(context, %v) => %d write counts; expected %d",
+				test.arg,
+				mw.WriteCount,
+				test.expectedWriteCount,
+			)
+		}
+
+		// Sort expected and got args slice by key name since there is no send order
+		// guarantee.
+		bus.ByMockWriterArgs(bus.WriteArgKey).Sort(test.expectedWriteArgs)
+		bus.ByMockWriterArgs(bus.WriteArgKey).Sort(mw.Args)
+
+		if !reflect.DeepEqual(mw.Args, test.expectedWriteArgs) {
+			t.Errorf(
+				"Forwarder.Write(context, %v) => %v;\nexpected %v",
+				test.arg,
+				mw.Args,
+				test.expectedWriteArgs,
+			)
+		}
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,37 +1,37 @@
-hash: 1b133d31fa2d02d7808eb40843dc795227129959cd940c3023636bc8eb9162b3
-updated: 2016-09-07T12:59:00.166637116+02:00
+hash: 07403953c92452205aa76dc3c89cd9467ec20d0c9ec021c6928f1486d383d254
+updated: 2016-09-08T14:03:40.070500954-04:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: a11ddd7a070196035bc94b6c04a2a0114c06a395
   subpackages:
   - aws
-  - aws/credentials
-  - aws/defaults
-  - service/ec2
   - aws/awserr
-  - aws/credentials/ec2rolecreds
   - aws/awsutil
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/defaults
+  - aws/ec2metadata
   - aws/request
   - aws/service
   - aws/service/serviceinfo
-  - internal/protocol/ec2query
-  - internal/signer/v4
-  - aws/ec2metadata
-  - aws/corehandlers
   - internal/endpoints
+  - internal/protocol/ec2query
   - internal/protocol/query/queryutil
-  - internal/protocol/xml/xmlutil
   - internal/protocol/rest
+  - internal/protocol/xml/xmlutil
+  - internal/signer/v4
+  - service/ec2
 - name: github.com/Azure/azure-sdk-for-go
-  version: 34467930a15f0d2872168deb11435b8ac3d863bb
+  version: a9e8b991cde41aeef7dde53fc1ee2c74af5ed30b
   subpackages:
   - arm/compute
   - arm/network
 - name: github.com/Azure/go-autorest
   version: 3a30515cff8ca0504593132b55cd9e5aa2136f74
   subpackages:
-  - autorest/azure
   - autorest
+  - autorest/azure
   - autorest/date
   - autorest/to
   - autorest/validation
@@ -42,7 +42,7 @@ imports:
 - name: github.com/BurntSushi/toml
   version: 99064174e013895bbd9b025c31100bd1d9b590ca
 - name: github.com/davecgh/go-spew
-  version: 6cf5744a041a0022271cefed95ba843f6d87fd51
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/dgrijalva/jwt-go
@@ -82,10 +82,10 @@ imports:
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/token
-  - json/parser
   - hcl/scanner
   - hcl/strconv
+  - hcl/token
+  - json/parser
   - json/scanner
   - json/token
 - name: github.com/hashicorp/serf
@@ -94,6 +94,15 @@ imports:
   - coordinate
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/influxdata/influxdb
+  version: 0521c2a03ed24aa7cddcbd666f2e0f895c9109fe
+  subpackages:
+  - models
+  - pkg/escape
+- name: github.com/influxdb/influxdb
+  version: 0521c2a03ed24aa7cddcbd666f2e0f895c9109fe
+  subpackages:
+  - client
 - name: github.com/julienschmidt/httprouter
   version: d8ff598a019f2c7bad0980917a588193cf26666e
 - name: github.com/klauspost/crc32
@@ -101,7 +110,7 @@ imports:
 - name: github.com/kr/fs
   version: 2788f0dbd16903de03cb8186e5c7d97b69ad387b
 - name: github.com/magiconair/properties
-  version: 61b492c03cf472e0c6419be5899b8e0dc28b1b88
+  version: 0723e352fa358f9322c938cc2dadda874e9151a9
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
@@ -119,7 +128,7 @@ imports:
 - name: github.com/pkg/errors
   version: 17b591df37844cde689f4d5813e5cea0927d8dd2
 - name: github.com/pkg/sftp
-  version: a71e8f580e3b622ebff585309160b1cc549ef4d2
+  version: 8197a2e580736b78d704be0fc47b2324c0591a32
 - name: github.com/prometheus/client_golang
   version: ea6e1db4cb8127eeb0b6954f7320363e5451820f
   subpackages:
@@ -132,41 +141,45 @@ imports:
   version: c25d279efa03dacfede108044f9506ce65c1992e
   subpackages:
   - expfmt
-  - model
-  - log
-  - route
   - internal/bitbucket.org/ww/goautoneg
+  - log
+  - model
+  - route
 - name: github.com/prometheus/procfs
   version: abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
 - name: github.com/prometheus/prometheus
-  version: 24db241bd556fd45854dd310692ac291de7d24e1
+  version: 36fbdcc30fd13ad796381dc934742c559feeb1b5
   subpackages:
   - config
-  - promql
-  - retrieval
-  - rules
-  - storage/local
-  - storage/metric
-  - web
-  - retrieval/discovery
-  - util/httputil
-  - storage
-  - util/stats
-  - util/strutil
-  - util/testutil
-  - relabel
   - notifier
-  - template
-  - storage/local/codable
-  - storage/local/index
-  - util/flock
-  - web/api/v1
-  - web/ui
+  - promql
+  - relabel
+  - retrieval
+  - retrieval/discovery
   - retrieval/discovery/consul
   - retrieval/discovery/dns
   - retrieval/discovery/kubernetes
   - retrieval/discovery/marathon
+  - rules
+  - storage
+  - storage/local
+  - storage/local/codable
+  - storage/local/index
+  - storage/metric
+  - storage/remote
+  - storage/remote/graphite
+  - storage/remote/influxdb
+  - storage/remote/opentsdb
+  - template
+  - util/flock
+  - util/httputil
+  - util/stats
+  - util/strutil
+  - util/testutil
   - util/treecache
+  - web
+  - web/api/v1
+  - web/ui
 - name: github.com/rcrowley/go-metrics
   version: bdb33529eca3e55eac7328e07c57012a797af602
 - name: github.com/samuel/go-zookeeper
@@ -178,7 +191,7 @@ imports:
 - name: github.com/serialx/hashring
   version: 75d57fa264ad17fd929304dfdb02c8e278c5c01c
 - name: github.com/Shopify/sarama
-  version: e03d23b5a4fa1a72c30eace0403d7c2c3b5de55e
+  version: 482c471fbf73dc2ac66945187f811581f008c24a
 - name: github.com/Sirupsen/logrus
   version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
 - name: github.com/spf13/afero
@@ -204,43 +217,56 @@ imports:
   version: 6ae1797c0b42b9323fc27ff7dcf568df88f2f33d
   subpackages:
   - leveldb
-  - leveldb/filter
-  - leveldb/iterator
-  - leveldb/opt
-  - leveldb/util
   - leveldb/cache
   - leveldb/comparer
   - leveldb/errors
+  - leveldb/filter
+  - leveldb/iterator
   - leveldb/journal
   - leveldb/memdb
+  - leveldb/opt
   - leveldb/storage
   - leveldb/table
+  - leveldb/util
 - name: github.com/vaughan0/go-ini
   version: a98ad7ee00ec53921f08832bc06ecf7fd600e6a1
 - name: golang.org/x/crypto
   version: 9e590154d2353f3f5e1b24da7275686040dcf491
-  repo: https://github.com/golang/crypto.git
-  vcs: git
   subpackages:
-  - pkcs12
-  - ssh
   - curve25519
   - ed25519
   - ed25519/internal/edwards25519
+  - ssh
 - name: golang.org/x/net
-  version: 1358eff22f0dd0c54fc521042cc607f6ff4b531a
+  version: 9313baa13d9262e49d07b20ed57dceafcd7240cc
   subpackages:
   - context
   - context/ctxhttp
+  - http2
+  - http2/hpack
+  - internal/timeseries
+  - lex/httplex
+  - trace
 - name: golang.org/x/sys
-  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  version: 30de6d19a3bd89a5f38ae4028e23aaa5582648af
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: d074c16409f4f7aae134590a94a9c82b72f1cd1e
+  version: 1e65e9bf72c307081cea196f47ef37aed17eb316
   subpackages:
   - transform
   - unicode/norm
+- name: google.golang.org/grpc
+  version: 0e6ec3a4501ee9ee2d023abe92e436fd04ed4081
+  subpackages:
+  - codes
+  - credentials
+  - grpclog
+  - internal
+  - metadata
+  - naming
+  - peer
+  - transport
 - name: gopkg.in/fsnotify.v1
   version: a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb
 - name: gopkg.in/inf.v0

--- a/glide.yaml
+++ b/glide.yaml
@@ -92,3 +92,4 @@ import:
 - package: github.com/dgrijalva/jwt-go
 - package: github.com/pkg/errors
   version: ~0.7.0
+- package: github.com/influxdb/influxdb

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func main() {
 	vulcan.AddCommand(cmd.Indexer())
 	vulcan.AddCommand(cmd.Ingester)
 	vulcan.AddCommand(cmd.Querier())
+	vulcan.AddCommand(cmd.Forwarder())
 
 	vulcan.AddCommand(cmd.Version(hash, version))
 


### PR DESCRIPTION
- Initial implementation of vulcan forwarder as a companion service for prometheus (v1.1.0 and higher) that receives write requests over grpc from prometheus and writes them to the message bus.

- glide updated to handle vendor dependency on the influxdb client.

