### PR TITLE
convert: migrate to remote.WriteRequest from dto.MetricFamily

### DIFF
--- a/cmd/indexer.go
+++ b/cmd/indexer.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -25,6 +24,7 @@ import (
 	"github.com/digitalocean/vulcan/kafka"
 	"github.com/digitalocean/vulcan/storage"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/olivere/elastic"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
@@ -40,6 +40,7 @@ func Indexer() *cobra.Command {
 		Use:   "indexer",
 		Short: "consumes metrics from the bus and makes them searchable",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			log.SetLevel(log.DebugLevel)
 			// bind pflags to viper so they are settable by env variables
 			cmd.Flags().VisitAll(func(f *pflag.Flag) {
 				viper.BindPFlag(f.Name, f)
@@ -89,7 +90,7 @@ func Indexer() *cobra.Command {
 				http.Handle("/metrics", prometheus.Handler())
 				http.ListenAndServe(":8080", nil)
 			}()
-			log.Println("running...")
+
 			return i.Run()
 		},
 	}

--- a/convert/promtexttosg.go
+++ b/convert/promtexttosg.go
@@ -15,209 +15,64 @@
 package convert
 
 import (
-	"fmt"
-	"io"
 	"time"
 
 	"github.com/digitalocean/vulcan/bus"
 
-	dto "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/expfmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/remote"
 )
 
 // PromTextToSG reads prometheus metrics in text exposition format and
 // produces a SampleGroup
-func PromTextToSG(in io.Reader) (bus.SampleGroup, error) {
-	fam := []*dto.MetricFamily{}
-	dec := expfmt.NewDecoder(in, expfmt.FmtText)
-	for {
-		var f dto.MetricFamily
-		err := dec.Decode(&f)
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return bus.SampleGroup{}, err
-		}
-		fam = append(fam, &f)
+func PromTextToSG(in []byte) (bus.SampleGroup, error) {
+	wr := &remote.WriteRequest{}
+
+	if err := proto.Unmarshal(in, wr); err != nil {
+		return nil, err
 	}
-	sg := familyToSampleGroup(fam)
+
+	sg := writeRequestToSampleGroup(wr)
 	return sg, nil
 }
 
-const (
-	labelType     = "__type__"
-	labelLE       = "le"
-	labelQuantile = "quantile"
+func writeRequestToSampleGroup(wr *remote.WriteRequest) bus.SampleGroup {
+	sg := bus.SampleGroup{}
 
-	suffixBucket = "_bucket"
-	suffixCount  = "_count"
-	suffixSum    = "_sum"
+	for _, ts := range wr.Timeseries {
+		// Create metric attribute for TimeSeries samples
+		m := bus.Metric{
+			Labels: map[string]string{},
+		}
 
-	typeCounter   = "counter"
-	typeGauge     = "gauge"
-	typeHistogram = "histogram"
-	typeSummary   = "summary"
-)
+		for _, lp := range ts.Labels {
+			m.Labels[lp.Name] = lp.Value
 
-func familyToSampleGroup(metricFamilies []*dto.MetricFamily) bus.SampleGroup {
-	samples := bus.SampleGroup{}
-	for _, mf := range metricFamilies {
-		for _, prom := range mf.GetMetric() {
-			m := bus.Metric{
-				Name:   mf.GetName(),
-				Labels: map[string]string{},
+			if lp.Name == model.MetricNameLabel {
+				m.Name = lp.Value
 			}
-			for _, label := range prom.GetLabel() {
-				m.Labels[label.GetName()] = label.GetValue()
-			}
+		}
 
-			switch mf.GetType() {
-			case dto.MetricType_COUNTER:
-				samples = append(samples, newCounterSample(prom, m))
-			case dto.MetricType_GAUGE:
-				samples = append(samples, newGaugeSample(prom, m))
-			case dto.MetricType_HISTOGRAM:
-				samples = collectHistogramSamples(samples, prom, m)
-			case dto.MetricType_SUMMARY:
-				samples = collectSummarySamples(samples, prom, m)
-			}
+		// Convert prometheus samples & add to Sample Group
+		for _, ps := range ts.Samples {
+			sg = append(sg, &bus.Sample{
+				Metric: m,
+				Datapoint: bus.Datapoint{
+					Timestamp: checkTimestamp(ps),
+					Value:     ps.Value,
+				},
+			})
 		}
 	}
 
-	return samples
+	return sg
 }
 
-func newCounterSample(prom *dto.Metric, m bus.Metric) *bus.Sample {
-	s := bus.Sample{
-		Metric: m,
-		Datapoint: bus.Datapoint{
-			Value:     prom.Counter.GetValue(),
-			Timestamp: promTimestamp(prom),
-		},
-	}
-	s.Metric.Labels[labelType] = typeCounter
-
-	return &s
-}
-
-func newGaugeSample(prom *dto.Metric, m bus.Metric) *bus.Sample {
-	s := bus.Sample{
-		Metric: m,
-		Datapoint: bus.Datapoint{
-			Value:     prom.Gauge.GetValue(),
-			Timestamp: promTimestamp(prom),
-		},
-	}
-	s.Metric.Labels[labelType] = typeGauge
-
-	return &s
-}
-
-func collectHistogramSamples(samples bus.SampleGroup, prom *dto.Metric, m bus.Metric) bus.SampleGroup {
-	// add bucket values, sum, and count for this prometheus metric
-	m.Labels[labelType] = typeHistogram
-	bucketName := m.Name + suffixBucket
-
-	for _, b := range prom.Histogram.Bucket {
-		myMetric := cloneMetric(m)
-		myMetric.Name = bucketName
-		myMetric.Labels[labelLE] = fmt.Sprint(b.GetUpperBound())
-
-		s := bus.Sample{
-			Metric: myMetric,
-			Datapoint: bus.Datapoint{
-				Value:     float64(b.GetCumulativeCount()),
-				Timestamp: promTimestamp(prom),
-			},
-		}
-		samples = append(samples, &s)
+func checkTimestamp(ps *remote.Sample) bus.Timestamp {
+	if ps.TimestampMs != 0 {
+		return bus.Timestamp(ps.TimestampMs)
 	}
 
-	// do sum
-	sum := cloneMetric(m)
-	sum.Name = sum.Name + suffixSum
-	s := bus.Sample{
-		Metric: sum,
-		Datapoint: bus.Datapoint{
-			Value:     float64(*prom.Histogram.SampleSum),
-			Timestamp: promTimestamp(prom),
-		},
-	}
-	samples = append(samples, &s)
-
-	// do count
-	count := cloneMetric(m)
-	count.Name = count.Name + suffixCount
-	s = bus.Sample{
-		Metric: count,
-		Datapoint: bus.Datapoint{
-			Value:     float64(*prom.Histogram.SampleCount),
-			Timestamp: promTimestamp(prom),
-		},
-	}
-	samples = append(samples, &s)
-
-	return samples
-}
-
-func collectSummarySamples(samples bus.SampleGroup, prom *dto.Metric, m bus.Metric) bus.SampleGroup {
-	m.Labels[labelType] = typeSummary
-
-	for _, q := range prom.Summary.Quantile {
-		myMetric := cloneMetric(m)
-		myMetric.Labels[labelQuantile] = fmt.Sprint(q.GetQuantile())
-		s := bus.Sample{
-			Metric: myMetric,
-			Datapoint: bus.Datapoint{
-				Value:     float64(q.GetValue()),
-				Timestamp: promTimestamp(prom),
-			},
-		}
-		samples = append(samples, &s)
-	}
-
-	// do sum
-	sum := cloneMetric(m)
-	sum.Name = sum.Name + suffixSum
-	s := bus.Sample{
-		Metric: sum,
-		Datapoint: bus.Datapoint{
-			Value:     float64(*prom.Summary.SampleSum),
-			Timestamp: promTimestamp(prom),
-		},
-	}
-	samples = append(samples, &s)
-
-	// do count
-	count := cloneMetric(m)
-	count.Name = count.Name + suffixCount
-	s = bus.Sample{
-		Metric: count,
-		Datapoint: bus.Datapoint{
-			Value:     float64(*prom.Summary.SampleCount),
-			Timestamp: promTimestamp(prom),
-		},
-	}
-	samples = append(samples, &s)
-
-	return samples
-}
-
-func promTimestamp(m *dto.Metric) bus.Timestamp {
-	if m.TimestampMs != nil {
-		return bus.Timestamp(*m.TimestampMs)
-	}
 	return bus.Timestamp(time.Now().UnixNano() / 1e6)
-}
-
-func cloneMetric(m bus.Metric) bus.Metric {
-	result := bus.Metric{
-		Name:   m.Name,
-		Labels: map[string]string{},
-	}
-	for k, v := range m.Labels {
-		result.Labels[k] = v
-	}
-	return result
 }

--- a/convert/promtexttosg_test.go
+++ b/convert/promtexttosg_test.go
@@ -12,31 +12,726 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package convert_test
+package convert
 
 import (
-	"bytes"
+	"reflect"
 	"testing"
+	"time"
 
-	"github.com/digitalocean/vulcan/convert"
+	"github.com/digitalocean/vulcan/bus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/remote"
 )
 
-func TestPromTextToSG(t *testing.T) {
-	sg, err := convert.PromTextToSG(bytes.NewReader([]byte(`# HELP node_network_receive_packets Network device statistic receive_packets.
-# TYPE node_network_receive_packets gauge
-node_network_receive_packets{device="eth0",job="docker-compose-node-exporter",instance="node_exporter:9100"} 826 1464748563529
-node_network_receive_packets{device="lo",job="docker-compose-node-exporter",instance="node_exporter:9100"} 0 1464748563529
-# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
-# TYPE go_memstats_alloc_bytes_total counter
-go_memstats_alloc_bytes_total{job="docker-compose-node-exporter",instance="node_exporter:9100"} 3.90805888e+08 1464748563529
-# HELP node_memory_SReclaimable Memory information field SReclaimable.
-# TYPE node_memory_SReclaimable gauge
-node_memory_SReclaimable{job="docker-compose-node-exporter",instance="node_exporter:9100"} 4.2274816e+07 1464748563529
-`)))
-	if err != nil {
-		t.Error(err)
+func TestWriteRequestToSampleGroup(t *testing.T) {
+	var happyPathTests = []struct {
+		name     string
+		desc     string
+		arg      *remote.WriteRequest
+		expected bus.SampleGroup
+	}{
+		{
+			name: "a",
+			desc: "1 timeseries set from wr with 5 samples",
+			arg: &remote.WriteRequest{
+				Timeseries: []*remote.TimeSeries{
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+							&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+							&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+							&remote.LabelPair{Name: model.MetricNameLabel, Value: "sammy_test"},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(1.34566),
+								TimestampMs: int64(649957774751),
+							},
+							&remote.Sample{
+								Value:       float64(2.34566),
+								TimestampMs: int64(649957774752),
+							},
+							&remote.Sample{
+								Value:       float64(3.34566),
+								TimestampMs: int64(649957774753),
+							},
+							&remote.Sample{
+								Value:       float64(4.34566),
+								TimestampMs: int64(649957774754),
+							},
+							&remote.Sample{
+								Value:       float64(5.34566),
+								TimestampMs: int64(649957774755),
+							},
+						},
+					},
+				},
+			},
+			expected: bus.SampleGroup{
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(1.34566),
+						Timestamp: bus.Timestamp(int64(649957774751)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(2.34566),
+						Timestamp: bus.Timestamp(int64(649957774752)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(3.34566),
+						Timestamp: bus.Timestamp(int64(649957774753)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(4.34566),
+						Timestamp: bus.Timestamp(int64(649957774754)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(5.34566),
+						Timestamp: bus.Timestamp(int64(649957774755)),
+					},
+				},
+			},
+		},
+
+		{
+			name: "b",
+			desc: "5 timeseries set from wr with 1 sample each",
+			arg: &remote.WriteRequest{
+				Timeseries: []*remote.TimeSeries{
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+							&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+							&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+							&remote.LabelPair{Name: model.MetricNameLabel, Value: "sammy_test1"},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(1.34566),
+								TimestampMs: int64(649957774751),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+							&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+							&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+							&remote.LabelPair{Name: model.MetricNameLabel, Value: "sammy_test2"},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(2.34566),
+								TimestampMs: int64(649957774752),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+							&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+							&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+							&remote.LabelPair{Name: model.MetricNameLabel, Value: "sammy_test3"},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(3.34566),
+								TimestampMs: int64(649957774753),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+							&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+							&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+							&remote.LabelPair{Name: model.MetricNameLabel, Value: "sammy_test4"},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(4.34566),
+								TimestampMs: int64(649957774754),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+							&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+							&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+							&remote.LabelPair{Name: model.MetricNameLabel, Value: "sammy_test5"},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(5.34566),
+								TimestampMs: int64(649957774755),
+							},
+						},
+					},
+				},
+			},
+			expected: bus.SampleGroup{
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test1",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test1",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(1.34566),
+						Timestamp: bus.Timestamp(int64(649957774751)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test2",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test2",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(2.34566),
+						Timestamp: bus.Timestamp(int64(649957774752)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test3",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test3",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(3.34566),
+						Timestamp: bus.Timestamp(int64(649957774753)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test4",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test4",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(4.34566),
+						Timestamp: bus.Timestamp(int64(649957774754)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test5",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test5",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(5.34566),
+						Timestamp: bus.Timestamp(int64(649957774755)),
+					},
+				},
+			},
+		},
+
+		{
+			name: "c",
+			desc: "5 timeseries set from wr with 3 samples each",
+			arg: &remote.WriteRequest{
+				Timeseries: []*remote.TimeSeries{
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+							&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+							&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+							&remote.LabelPair{Name: model.MetricNameLabel, Value: "sammy_test1"},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(1.34566),
+								TimestampMs: int64(649957774751),
+							},
+							&remote.Sample{
+								Value:       float64(1.44566),
+								TimestampMs: int64(749957774751),
+							},
+							&remote.Sample{
+								Value:       float64(1.54566),
+								TimestampMs: int64(849957774751),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+							&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+							&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+							&remote.LabelPair{Name: model.MetricNameLabel, Value: "sammy_test2"},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(2.34566),
+								TimestampMs: int64(649957774752),
+							},
+							&remote.Sample{
+								Value:       float64(2.44566),
+								TimestampMs: int64(749957774752),
+							},
+							&remote.Sample{
+								Value:       float64(2.54566),
+								TimestampMs: int64(849957774752),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+							&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+							&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+							&remote.LabelPair{Name: model.MetricNameLabel, Value: "sammy_test3"},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(3.34566),
+								TimestampMs: int64(649957774753),
+							},
+							&remote.Sample{
+								Value:       float64(3.44566),
+								TimestampMs: int64(749957774753),
+							},
+							&remote.Sample{
+								Value:       float64(3.54566),
+								TimestampMs: int64(849957774753),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+							&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+							&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+							&remote.LabelPair{Name: model.MetricNameLabel, Value: "sammy_test4"},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(4.34566),
+								TimestampMs: int64(649957774754),
+							},
+							&remote.Sample{
+								Value:       float64(4.44566),
+								TimestampMs: int64(749957774754),
+							},
+							&remote.Sample{
+								Value:       float64(4.54566),
+								TimestampMs: int64(849957774754),
+							},
+						},
+					},
+					&remote.TimeSeries{
+						Labels: []*remote.LabelPair{
+							&remote.LabelPair{Name: model.MetricsPathLabel, Value: "/metrics"},
+							&remote.LabelPair{Name: model.AlertNameLabel, Value: "boo"},
+							&remote.LabelPair{Name: model.InstanceLabel, Value: "inst8888"},
+							&remote.LabelPair{Name: model.MetricNameLabel, Value: "sammy_test5"},
+						},
+						Samples: []*remote.Sample{
+							&remote.Sample{
+								Value:       float64(5.34566),
+								TimestampMs: int64(649957774755),
+							},
+							&remote.Sample{
+								Value:       float64(5.44566),
+								TimestampMs: int64(749957774755),
+							},
+							&remote.Sample{
+								Value:       float64(5.54566),
+								TimestampMs: int64(849957774755),
+							},
+						},
+					},
+				},
+			},
+			expected: bus.SampleGroup{
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test1",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test1",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(1.34566),
+						Timestamp: bus.Timestamp(int64(649957774751)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test1",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test1",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(1.44566),
+						Timestamp: bus.Timestamp(int64(749957774751)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test1",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test1",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(1.54566),
+						Timestamp: bus.Timestamp(int64(849957774751)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test2",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test2",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(2.34566),
+						Timestamp: bus.Timestamp(int64(649957774752)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test2",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test2",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(2.44566),
+						Timestamp: bus.Timestamp(int64(749957774752)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test2",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test2",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(2.54566),
+						Timestamp: bus.Timestamp(int64(849957774752)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test3",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test3",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(3.34566),
+						Timestamp: bus.Timestamp(int64(649957774753)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test3",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test3",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(3.44566),
+						Timestamp: bus.Timestamp(int64(749957774753)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test3",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test3",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(3.54566),
+						Timestamp: bus.Timestamp(int64(849957774753)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test4",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test4",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(4.34566),
+						Timestamp: bus.Timestamp(int64(649957774754)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test4",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test4",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(4.44566),
+						Timestamp: bus.Timestamp(int64(749957774754)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test4",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test4",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(4.54566),
+						Timestamp: bus.Timestamp(int64(849957774754)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test5",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test5",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(5.34566),
+						Timestamp: bus.Timestamp(int64(649957774755)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test5",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test5",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(5.44566),
+						Timestamp: bus.Timestamp(int64(749957774755)),
+					},
+				},
+				&bus.Sample{
+					Metric: bus.Metric{
+						Name: "sammy_test5",
+						Labels: map[string]string{
+							model.MetricsPathLabel: "/metrics",
+							model.AlertNameLabel:   "boo",
+							model.InstanceLabel:    "inst8888",
+							model.MetricNameLabel:  "sammy_test5",
+						},
+					},
+					Datapoint: bus.Datapoint{
+						Value:     float64(5.54566),
+						Timestamp: bus.Timestamp(int64(849957774755)),
+					},
+				},
+			},
+		},
 	}
-	if len(sg) != 4 {
-		t.Errorf("expected 4 samples but got %d", len(sg))
+
+	for i, test := range happyPathTests {
+		t.Logf("happy path test %d, id %s: %q", i, test.name, test.desc)
+
+		tc := &testWriteRequestToSampleGroup{
+			input:    test.arg,
+			expected: test.expected,
+		}
+
+		t.Run(test.name, tc.validate)
+	}
+}
+
+type testWriteRequestToSampleGroup struct {
+	input    *remote.WriteRequest
+	expected bus.SampleGroup
+}
+
+func (tc *testWriteRequestToSampleGroup) validate(t *testing.T) {
+	got := writeRequestToSampleGroup(tc.input)
+
+	if !reflect.DeepEqual(got, tc.expected) {
+		t.Errorf(
+			"writeRequestToSampleGroup(%v) => %v; expected %v",
+			tc.input,
+			got,
+			tc.expected,
+		)
+	}
+}
+
+func TestCheckTimestamp(t *testing.T) {
+	var tests = []struct {
+		name     string
+		desc     string
+		input    *remote.Sample
+		expected bus.Timestamp
+	}{
+		{
+			name: "a",
+			desc: "valid timestamp in remote.Sample",
+			input: &remote.Sample{
+				Value:       float64(5.34566),
+				TimestampMs: int64(649957774755),
+			},
+			expected: bus.Timestamp(649957774755),
+		},
+		{
+			name: "b",
+			desc: "missing timestamp in remote.Sample",
+			input: &remote.Sample{
+				Value: float64(5.34566),
+			},
+			expected: bus.Timestamp(time.Now().UnixNano() / 1e6),
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("test %d: %q", i, test.desc)
+
+		tc := &testCheckTimestamp{
+			input:    test.input,
+			expected: test.expected,
+		}
+
+		t.Run(test.name, tc.validate)
+	}
+}
+
+type testCheckTimestamp struct {
+	input    *remote.Sample
+	expected bus.Timestamp
+}
+
+func (tc *testCheckTimestamp) validate(t *testing.T) {
+	got := checkTimestamp(tc.input)
+
+	if got-tc.expected > bus.Timestamp(1) {
+		t.Errorf(
+			"checkTimestamp(%v) => %d; expected %d",
+			tc.input,
+			got,
+			tc.expected,
+		)
 	}
 }

--- a/kafka/ack_source.go
+++ b/kafka/ack_source.go
@@ -15,7 +15,6 @@
 package kafka
 
 import (
-	"bytes"
 	"log"
 	"sync"
 	"time"
@@ -41,7 +40,7 @@ type DefaultConverter struct{}
 
 // Convert implements Converter.
 func (dc DefaultConverter) Convert(msg *sarama.ConsumerMessage) (bus.SampleGroup, error) {
-	return convert.PromTextToSG(bytes.NewReader(msg.Value))
+	return convert.PromTextToSG(msg.Value)
 }
 
 // AckSource represents an object that processes SampleGroups received

--- a/querier/series.go
+++ b/querier/series.go
@@ -21,6 +21,7 @@ import (
 	"github.com/digitalocean/vulcan/bus"
 	"github.com/digitalocean/vulcan/convert"
 	"github.com/digitalocean/vulcan/storage"
+
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage/local"
 	"github.com/prometheus/prometheus/storage/metric"


### PR DESCRIPTION
- Convert to convert prometheus.storage.remote.WriteRequest to vulcan.bus.Sample

- Changes made convert package and kafka 

- Added debug logging wrapper, ingester, indexer
