### PR TITLE
tools: set glide to v0.12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ go:
   - 1.7
 before_install:
   - go get github.com/golang/lint/golint
-  - curl -fsSL https://github.com/Masterminds/glide/releases/download/v0.11.1/glide-v0.11.1-linux-amd64.tar.gz -o glide.tar.gz
-  - echo "de0c7870738c6bc11128761d53a99ad68687b0a213fe52cea15ad05d93f10e42  glide.tar.gz" | sha256sum -c -
+  - curl -fsSL https://github.com/Masterminds/glide/releases/download/v0.12.2/glide-v0.12.2-linux-amd64.tar.gz -o glide.tar.gz
+  - echo "edd398b4e94116b289b9494d1c13ec2ea37386bad4ada91ecc9825f96b12143c  glide.tar.gz" | sha256sum -c -
   - tar -xf glide.tar.gz --strip-components=1 -C "$GOPATH/bin" linux-amd64/glide
   - rm glide.tar.gz
 

--- a/dev/vulcan.dockerfile
+++ b/dev/vulcan.dockerfile
@@ -1,8 +1,8 @@
 FROM golang:1.6.3-wheezy
 
 ENV GLIDEPATH /glide
-ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/v0.11.1/glide-v0.11.1-linux-amd64.tar.gz
-ENV GLIDE_DOWNLOAD_SHA256 de0c7870738c6bc11128761d53a99ad68687b0a213fe52cea15ad05d93f10e42
+ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/v0.12.2/glide-v0.12.2-linux-amd64.tar.gz
+ENV GLIDE_DOWNLOAD_SHA256 edd398b4e94116b289b9494d1c13ec2ea37386bad4ada91ecc9825f96b12143c
 
 RUN mkdir -p $GLIDEPATH \
  && curl -fsSL $GLIDE_DOWNLOAD_URL -o glide.tar.gz \


### PR DESCRIPTION
This upgrades the version of glide used in Travis and in the docker-compose docker environment to the current latest (v0.12.2). When modifying dependencies, glide v0.12.x will sort the yaml and lock file to make future diffs more pleasant.