### PR TITLE
forwarder: log each batch write at debug level not info

### DIFF
--- a/forwarder/writer.go
+++ b/forwarder/writer.go
@@ -80,7 +80,7 @@ func (f *Forwarder) Write(ctx context.Context, req *remote.WriteRequest) (*remot
 
 		ll.WithFields(log.Fields{
 			"timeseries_count": len(wr.Timeseries),
-		}).Info("writing to bus")
+		}).Debug("writing to bus")
 
 		if err := f.writer.Write(key, wr); err != nil {
 			ll.WithError(err).Error("failed to write to bus")


### PR DESCRIPTION
Logging each batch write at info level is too verbose.