### PR TITLE
persist glide cache on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,7 @@ script:
   - make vet
   - make lint
   - make
+
+cache:
+  directories:
+    - $HOME/.glide/cache


### PR DESCRIPTION
Glide caches the repos it uses when fulfilling dependencies at `~/.glide/cache`

Having travis know about this cache should speed up CI.