### PR TITLE
ingesters should load balance messages

### DIFF
--- a/bus/ack_source.go
+++ b/bus/ack_source.go
@@ -34,6 +34,7 @@ type AckPayload struct {
 // is closed. The caller should call Err() after the channel is closed.
 // Err() will return nil if the source closed without error, otherwise
 // it will return the first error encountered.
+// DEPRECATED in favor of bus.Source
 type AckSource interface {
 	Chan() <-chan AckPayload
 	Err() error

--- a/bus/datapoint.go
+++ b/bus/datapoint.go
@@ -14,7 +14,8 @@
 
 package bus
 
-// Datapoint is 128 bits of time and a value
+// Datapoint is 128 bits of time and a value.
+// Deprecated.
 type Datapoint struct {
 	Timestamp Timestamp
 	Value     float64

--- a/bus/metric.go
+++ b/bus/metric.go
@@ -19,6 +19,7 @@ package bus
 // TODO each prometheus metric also has a type (counter, gauge...) we should
 // probably make this a field in the Metric struct. Right now the type is
 // recorded as a label named "__type__".
+// Deprecated in favor of model.TimeSeries
 type Metric struct {
 	Name   string
 	Labels map[string]string

--- a/bus/sample.go
+++ b/bus/sample.go
@@ -14,7 +14,8 @@
 
 package bus
 
-// Sample is a metric and a single associated datapoint
+// Sample is a metric and a single associated datapoint.
+// Deprecated in favor of model.TimeSeries
 type Sample struct {
 	Metric    Metric
 	Datapoint Datapoint

--- a/bus/sample_group.go
+++ b/bus/sample_group.go
@@ -14,5 +14,6 @@
 
 package bus
 
-// SampleGroup is a list of samples
+// SampleGroup is a list of samples.
+// Deprecated in favor of model.TimeSeriesBatch.
 type SampleGroup []*Sample

--- a/bus/source.go
+++ b/bus/source.go
@@ -1,0 +1,39 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bus
+
+import "github.com/digitalocean/vulcan/model"
+
+// SourcePayload is a TimeSeriesBatch and an Ack function to signal that
+// the payload has been processed.
+type SourcePayload struct {
+	TimeSeriesBatch model.TimeSeriesBatch
+	Ack             func()
+}
+
+// Source is a mechanism for reading from the bus.
+type Source interface {
+	// Error SHOULD ONLY be called AFTER the messages channel has closed.
+	// This lets the caller determine if the messages channel closed because
+	// of an error or completed.
+	Error() error
+	// Messages returns a readable channel of SourcePayload. The payloads'
+	// Ack function MUST be called after the caller is done processing the
+	// payload. The channel will be closed when the Source encounters an
+	// error or the stream finishes. The caller SHOULD call Error() after
+	// the channel closes to determine if the channel closed because of
+	// an error or not.
+	Messages() <-chan *SourcePayload
+}

--- a/cassandra/sample_writer.go
+++ b/cassandra/sample_writer.go
@@ -36,6 +36,7 @@ const (
 
 // SampleWriter represents an object that writes bus messages to the target
 // Cassandra database.
+// Deprecated in favor of cassandra.Writer
 type SampleWriter struct {
 	sess *gocql.Session
 }

--- a/cassandra/writer.go
+++ b/cassandra/writer.go
@@ -1,0 +1,100 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cassandra
+
+import (
+	"sync"
+
+	"github.com/digitalocean/vulcan/model"
+	"github.com/gocql/gocql"
+)
+
+// Writer implements ingester.Writer to persist TimeSeriesBatch samples
+// to Cassandra.
+type Writer struct {
+	s  *gocql.Session
+	ch chan *writerPayload
+}
+
+type writerPayload struct {
+	wg    *sync.WaitGroup
+	ts    *model.TimeSeries
+	errch chan error
+}
+
+// WriterConfig specifies how many goroutines should be used in writing
+// TimeSeries to Cassandra. The Session is expected to be already created
+// and ready to use.
+type WriterConfig struct {
+	NumWorkers int
+	Session    *gocql.Session
+}
+
+// NewWriter creates a Writer and starts the configured number of
+// goroutines to write to Cassandra concurrently.
+func NewWriter(config *WriterConfig) *Writer {
+	w := &Writer{
+		s:  config.Session,
+		ch: make(chan *writerPayload),
+	}
+	for n := 0; n < config.NumWorkers; n++ {
+		go w.worker()
+	}
+	return w
+}
+
+// Write implements the ingester.Write interface and allows the
+// ingester to write TimeSeriesBatch to Cassandra.
+func (w *Writer) Write(tsb model.TimeSeriesBatch) error {
+	wg := &sync.WaitGroup{}
+	errch := make(chan error, 1) // room for just the first error a worker encounters
+	wg.Add(len(tsb))
+	for _, ts := range tsb {
+		wp := &writerPayload{
+			wg:    wg,
+			ts:    ts,
+			errch: errch,
+		}
+		w.ch <- wp
+	}
+	wg.Wait()
+	select {
+	case err := <-errch:
+		return err
+	default:
+		return nil
+	}
+}
+
+func (w *Writer) worker() {
+	for m := range w.ch {
+		id := m.ts.ID()
+		for _, s := range m.ts.Samples {
+			err := w.write(id, s.TimestampMS, s.Value)
+			if err != nil {
+				// send error back on payload's errch; don't block the worker
+				select {
+				case m.errch <- err:
+				default:
+				}
+			}
+		}
+		m.wg.Done()
+	}
+}
+
+func (w *Writer) write(id string, at int64, value float64) error {
+	return w.s.Query(writeSampleCQL, value, id, at).Exec()
+}

--- a/cmd/forwarder.go
+++ b/cmd/forwarder.go
@@ -34,12 +34,20 @@ import (
 )
 
 const (
-	flagAddress          = "address"
-	flagKafkaTopic       = "kafka-topic"
-	flagKafkaAddrs       = "kafka-addrs"
-	flagKafkaClientID    = "kafka-client-id"
-	flagTelemetryPath    = "telemetry-path"
-	flagWebListenAddress = "web-listen-address"
+	flagAddress             = "address"
+	flagCassandraAddrs      = "cassandra-addrs"
+	flagCassandraKeyspace   = "cassandra-keyspace"
+	flagCassandraTimeout    = "cassandra-timeout"
+	flagCassandraNumConns   = "cassandra-num-conns"
+	flagKafkaAddrs          = "kafka-addrs"
+	flagKafkaClientID       = "kafka-client-id"
+	flagKafkaGroupID        = "kafka-group-id"
+	flagKafkaTopic          = "kafka-topic"
+	flagNumCassandraWorkers = "num-cassandra-workers"
+	flagNumKafkaWorkers     = "num-kafka-workers"
+	flagNumWorkers          = "num-workers"
+	flagTelemetryPath       = "telemetry-path"
+	flagWebListenAddress    = "web-listen-address"
 )
 
 // Forwarder handles parsing the command line options, initializes, and starts the

--- a/cmd/ingester.go
+++ b/cmd/ingester.go
@@ -59,13 +59,10 @@ func Ingester() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			i, err := ingester.NewIngester(&ingester.Config{
+			i := &ingester.Ingester{
 				NumWorkers: viper.GetInt(flagNumKafkaWorkers),
 				Source:     s,
 				Writer:     w,
-			})
-			if err != nil {
-				return err
 			}
 			go func() {
 				http.Handle("/metrics", prometheus.Handler())

--- a/cmd/ingester.go
+++ b/cmd/ingester.go
@@ -22,6 +22,7 @@ import (
 	"github.com/digitalocean/vulcan/cassandra"
 	"github.com/digitalocean/vulcan/ingester"
 	"github.com/digitalocean/vulcan/kafka"
+	"github.com/gocql/gocql"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
@@ -29,58 +30,61 @@ import (
 )
 
 // Ingester handles parsing the command line options, initializes, and starts the
-// ingester service accordingling.  It is the entry point for the Ingester
-// service.
-var Ingester = &cobra.Command{
-	Use:   "ingester",
-	Short: "runs the ingester service to consume metrics from kafka into cassandra",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// ensure cassandra tables
-		err := cassandra.SetupTables(strings.Split(viper.GetString("cassandra-addrs"), ","), viper.GetString("cassandra-keyspace"))
-		if err != nil {
-			return err
-		}
+// ingester service accordingling.
+func Ingester() *cobra.Command {
+	ingcmd := &cobra.Command{
+		Use:   "ingester",
+		Short: "runs the ingester service to consume metrics from kafka into cassandra",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cluster := gocql.NewCluster(strings.Split(viper.GetString(flagCassandraAddrs), ",")...)
+			cluster.Keyspace = viper.GetString(flagCassandraKeyspace)
+			cluster.Timeout = viper.GetDuration(flagCassandraTimeout)
+			cluster.NumConns = viper.GetInt(flagCassandraNumConns)
+			cluster.Consistency = gocql.LocalOne
+			cluster.ProtoVersion = 4
+			sess, err := cluster.CreateSession()
+			if err != nil {
+				return err
+			}
+			w := cassandra.NewWriter(&cassandra.WriterConfig{
+				NumWorkers: viper.GetInt(flagNumCassandraWorkers),
+				Session:    sess,
+			})
+			s, err := kafka.NewSource(&kafka.SourceConfig{
+				Addrs:    strings.Split(viper.GetString(flagKafkaAddrs), ","),
+				ClientID: viper.GetString(flagKafkaClientID),
+				GroupID:  viper.GetString(flagKafkaGroupID),
+				Topics:   []string{viper.GetString(flagKafkaTopic)},
+			})
+			if err != nil {
+				return err
+			}
+			i, err := ingester.NewIngester(&ingester.Config{
+				NumWorkers: viper.GetInt(flagNumKafkaWorkers),
+				Source:     s,
+				Writer:     w,
+			})
+			if err != nil {
+				return err
+			}
+			go func() {
+				http.Handle("/metrics", prometheus.Handler())
+				http.ListenAndServe(":8080", nil)
+			}()
+			return i.Run()
+		},
+	}
 
-		// create cassandra sample writer
-		sw, err := cassandra.NewSampleWriter(&cassandra.SampleWriterConfig{
-			CassandraAddrs: strings.Split(viper.GetString("cassandra-addrs"), ","),
-			Keyspace:       viper.GetString("cassandra-keyspace"),
-			Timeout:        30 * time.Second,
-		})
-		if err != nil {
-			return err
-		}
+	ingcmd.Flags().Duration(flagCassandraTimeout, time.Second*2, "cassandra timeout duration")
+	ingcmd.Flags().Int(flagCassandraNumConns, 2, "number of connections to cassandra per node")
+	ingcmd.Flags().Int(flagNumCassandraWorkers, 200, "number of ingester goroutines to write to cassandra")
+	ingcmd.Flags().Int(flagNumKafkaWorkers, 30, "number of ingester goroutines to process kafka messages")
+	ingcmd.Flags().String(flagCassandraAddrs, "", "one.example.com:9092,two.example.com:9092")
+	ingcmd.Flags().String(flagCassandraKeyspace, "vulcan", "cassandra keyspace to use")
+	ingcmd.Flags().String(flagKafkaAddrs, "", "one.example.com:9092,two.example.com:9092")
+	ingcmd.Flags().String(flagKafkaClientID, "vulcan-ingest", "set the kafka client id")
+	ingcmd.Flags().String(flagKafkaGroupID, "vulcan-ingester", "workers with the same groupID will join the same Kafka ConsumerGroup")
+	ingcmd.Flags().String(flagKafkaTopic, "vulcan", "set the kafka topic to consume")
 
-		// create kafka source
-		source, err := kafka.NewAckSource(&kafka.AckSourceConfig{
-			Addrs:     strings.Split(viper.GetString("kafka-addrs"), ","),
-			ClientID:  viper.GetString("kafka-client-id"),
-			Converter: kafka.DefaultConverter{},
-			Topic:     viper.GetString("kafka-topic"),
-		})
-		if err != nil {
-			return err
-		}
-		prometheus.MustRegister(source)
-
-		// create and start ingester
-		i := ingester.NewIngester(&ingester.Config{
-			SampleWriter: sw,
-			AckSource:    source,
-		})
-		prometheus.MustRegister(i)
-		go func() {
-			http.Handle("/metrics", prometheus.Handler())
-			http.ListenAndServe(":8080", nil)
-		}()
-		return i.Run()
-	},
-}
-
-func init() {
-	Ingester.Flags().String("cassandra-addrs", "", "one.example.com:9092,two.example.com:9092")
-	Ingester.Flags().String("cassandra-keyspace", "vulcan", "cassandra keyspace to use")
-	Ingester.Flags().String("kafka-addrs", "", "one.example.com:9092,two.example.com:9092")
-	Ingester.Flags().String("kafka-client-id", "vulcan-ingest", "set the kafka client id")
-	Ingester.Flags().String("kafka-topic", "vulcan", "set the kafka topic to consume")
+	return ingcmd
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 367e4e5b408e3aa1edfc39cf7669382ae63567295909bbef53bab64d70711534
-updated: 2016-09-20T11:53:45.728490645+02:00
+hash: 154ff1cc69f7bef811a0bbb56c78fbb721e88259844d1c6adf5ade8b8606070e
+updated: 2016-09-21T15:09:06.436271319+02:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: a11ddd7a070196035bc94b6c04a2a0114c06a395
@@ -39,6 +39,8 @@ imports:
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
+- name: github.com/bsm/sarama-cluster
+  version: 6d37f561b2a131e011c0cecf8a4d3c96b1e0a940
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
@@ -131,6 +133,7 @@ imports:
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
   - prometheus
+  - prometheus/promhttp
 - name: github.com/prometheus/client_model
   version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,3 +25,5 @@ import:
 - package: github.com/spf13/viper
 - package: github.com/pkg/errors
   version: 0.7.0
+- package: github.com/bsm/sarama-cluster
+  version: v2.1.1

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -16,142 +16,82 @@ package ingester
 
 import (
 	"sync"
-	"time"
 
 	"github.com/digitalocean/vulcan/bus"
-	"github.com/digitalocean/vulcan/storage"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
-const (
-	numIngestGoroutines = 400
-)
-
-type workPayload struct {
-	s  *bus.Sample
-	wg *sync.WaitGroup
-}
-
-// Ingester represents an object that consumes metrics from a bus and writes
-// them to a data storage.
+// Ingester consumes TimeSeriesBatch from a source and writes them at a
+// specified level of concurrency.
 type Ingester struct {
-	prometheus.Collector
-
-	sampleWriter storage.SampleWriter
-	ackSource    bus.AckSource
-
-	ingesterDurations *prometheus.SummaryVec
-	errorsTotal       *prometheus.CounterVec
-	work              chan workPayload
+	n int
+	s bus.Source
+	w Writer
 }
 
-// Config represents the configuration of an Ingester.  It requires an
-// AckSource implementer for the target message bus and a SampleWriter
-// implementer of the data storage system.
+// Config is used to create an Ingester.
 type Config struct {
-	SampleWriter storage.SampleWriter
-	AckSource    bus.AckSource
+	NumWorkers int
+	Source     bus.Source
+	Writer     Writer
 }
 
-// NewIngester creates a new instance of Ingester.
-func NewIngester(config *Config) *Ingester {
-	i := &Ingester{
-		sampleWriter: config.SampleWriter,
-		ackSource:    config.AckSource,
-		ingesterDurations: prometheus.NewSummaryVec(
-			prometheus.SummaryOpts{
-				Namespace: "vulcan",
-				Subsystem: "ingester",
-				Name:      "duration_nanoseconds",
-				Help:      "Durations of ingester stages",
-			},
-			[]string{"stage"},
-		),
-		errorsTotal: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: "vulcan",
-				Subsystem: "ingester",
-				Name:      "errors_total",
-				Help:      "Count of errors total of ingester stages",
-			},
-			[]string{"stage"},
-		),
-		work: make(chan workPayload),
-	}
-	for n := 0; n < numIngestGoroutines; n++ {
-		go i.worker()
-	}
-	return i
+func NewIngester(config *Config) (*Ingester, error) {
+	return &Ingester{
+		n: config.NumWorkers,
+		s: config.Source,
+		w: config.Writer,
+	}, nil
 }
 
-func (i *Ingester) worker() {
-	for w := range i.work {
-		t0 := time.Now()
-
-		log.WithFields(log.Fields{"sample": w.s}).Debug("writing sample")
-
-		err := i.sampleWriter.WriteSample(w.s)
-		w.wg.Done()
-		if err != nil {
-			log.WithError(err).Error("error writing sample to storage")
-
-			i.errorsTotal.WithLabelValues("write_sample").Add(1)
-			continue
-		}
-
-		i.ingesterDurations.WithLabelValues("write_sample").Observe(float64(time.Since(t0).Nanoseconds()))
-	}
-}
-
-// Describe implements prometheus.Collector.  Sends decriptors of the
-// instance's ingesterDurations and errorsTotal to the parameter ch.
-func (i *Ingester) Describe(ch chan<- *prometheus.Desc) {
-	i.ingesterDurations.Describe(ch)
-	i.errorsTotal.Describe(ch)
-}
-
-// Collect implements Collector.  Sends metrics collected by ingesterDurations
-// and errorsTotal to the parameter ch.
-func (i *Ingester) Collect(ch chan<- prometheus.Metric) {
-	i.ingesterDurations.Collect(ch)
-	i.errorsTotal.Collect(ch)
-}
-
-// Run starts the ingesting process by consuming from the message bus and
-// writing to the data storage system.
+// Run executes until an error occurs.
 func (i *Ingester) Run() error {
-	log.Info("running...")
-	ch := i.ackSource.Chan()
+	log.WithField("num_workers", i.n).Info("starting workers")
 
-	for payload := range ch {
-		log.WithFields(log.Fields{
-			"payload": payload.SampleGroup,
-		}).Debug("distributing sample group to workers")
-
-		i.writeSampleGroup(payload.SampleGroup)
-		payload.Done(nil)
+	var (
+		once     sync.Once
+		outerErr error
+		wg       sync.WaitGroup
+	)
+	done := make(chan struct{})
+	ch := i.s.Messages()
+	wg.Add(i.n)
+	for n := 0; n < i.n; n++ {
+		go func() {
+			defer wg.Done()
+			err := work(done, ch, i.w)
+			if err != nil {
+				once.Do(func() {
+					close(done)
+					outerErr = err
+				})
+			}
+		}()
 	}
-
-	return i.ackSource.Err()
+	wg.Wait()
+	// return error that caused a worker to fail
+	if outerErr != nil {
+		return outerErr
+	}
+	// return error that caused Source to stop
+	return i.s.Error()
 }
 
-func (i *Ingester) writeSampleGroup(sg bus.SampleGroup) {
-	var (
-		t0 = time.Now()
-		wg = &sync.WaitGroup{}
-	)
-
-	wg.Add(len(sg))
-
-	for _, s := range sg {
-		i.work <- workPayload{
-			s:  s,
-			wg: wg,
+func work(done <-chan struct{}, ch <-chan *bus.SourcePayload, w Writer) error {
+	for {
+		select {
+		case <-done:
+			return nil
+		case m, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			err := w.Write(m.TimeSeriesBatch)
+			if err != nil {
+				return err
+			}
+			m.Ack()
 		}
 	}
-
-	wg.Wait()
-	i.ingesterDurations.WithLabelValues("write_sample_group").Observe(float64(time.Since(t0).Nanoseconds()))
 }

--- a/ingester/writer.go
+++ b/ingester/writer.go
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bus
+package ingester
 
-// Timestamp is the milliseconds since the unix epoch. We use this instead of go's time.Time
-// since prometheus expects time to be represented in this way, and this value is also more
-// natural for our data model.
-//
-// converting to a go time.Time value is simple: `time.Unix(t/1000, (ts%1000)*1000*1000))`
-// but does cost extra instructions when we do this for EVERY datapoint only to turn around
-// and turn it back into a int64 for prometheus query engine. Plus, dividing is an expensive
-// instruction.
-// Deprecated.
-type Timestamp int64
+import "github.com/digitalocean/vulcan/model"
+
+// Writer is what the ingester expects to be provided in order to write
+// TimeSeriesBatch to a database.
+type Writer interface {
+	Write(model.TimeSeriesBatch) error
+}

--- a/kafka/ack_source.go
+++ b/kafka/ack_source.go
@@ -45,6 +45,7 @@ func (dc DefaultConverter) Convert(msg *sarama.ConsumerMessage) (bus.SampleGroup
 
 // AckSource represents an object that processes SampleGroups received
 // from the Kafka message bus.
+// Deprecated in favor of kafka.Source.
 type AckSource struct {
 	Converter Converter
 

--- a/kafka/source.go
+++ b/kafka/source.go
@@ -1,0 +1,114 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	cluster "github.com/bsm/sarama-cluster"
+	"github.com/digitalocean/vulcan/bus"
+	"github.com/digitalocean/vulcan/model"
+	"github.com/golang/protobuf/proto"
+	"github.com/prometheus/prometheus/storage/remote"
+)
+
+// SourceConfig is the details needed to create a connection to Kafka.
+type SourceConfig struct {
+	Addrs    []string
+	ClientID string
+	GroupID  string
+	Topics   []string
+}
+
+// Source reads from Kafka to fulfil the bus.Source interface.
+type Source struct {
+	c *cluster.Consumer
+	e error
+	m chan *bus.SourcePayload
+}
+
+// NewSource creates and starts a Kafka source.
+func NewSource(config *SourceConfig) (*Source, error) {
+	kcfg := cluster.NewConfig()
+	kcfg.ClientID = config.ClientID
+	c, err := cluster.NewConsumer(config.Addrs, config.GroupID, config.Topics, kcfg)
+	if err != nil {
+		return nil, err
+	}
+	s := &Source{
+		c: c,
+		m: make(chan *bus.SourcePayload),
+	}
+	go s.run()
+	return s, nil
+}
+
+// Error SHOULD ONLY be called AFTER the messages channel has closed.
+// This lets the caller determine if the messages channel closed because
+// of an error or completed.
+func (s *Source) Error() error {
+	return s.e
+}
+
+// Messages returns a readable channel of SourcePayload. The payloads'
+// Ack function MUST be called after the caller is done processing the
+// payload. The channel will be closed when the Source encounters an
+// error or the stream finishes. The caller SHOULD call Error() after
+// the channel closes to determine if the channel closed because of
+// an error or not.
+func (s *Source) Messages() <-chan *bus.SourcePayload {
+	return s.m
+}
+
+func (s *Source) run() {
+	defer close(s.m)
+	for m := range s.c.Messages() {
+		tsb, err := parseTimeSeriesBatch(m.Value)
+		if err != nil {
+			s.e = err
+			return
+		}
+		p := &bus.SourcePayload{
+			TimeSeriesBatch: tsb,
+			Ack: func() {
+				s.c.MarkOffset(m, "")
+			},
+		}
+		s.m <- p
+	}
+}
+
+func parseTimeSeriesBatch(in []byte) (model.TimeSeriesBatch, error) {
+	wr := &remote.WriteRequest{}
+	if err := proto.Unmarshal(in, wr); err != nil {
+		return nil, err
+	}
+	tsb := make(model.TimeSeriesBatch, 0, len(wr.Timeseries))
+	for _, protots := range wr.Timeseries {
+		ts := &model.TimeSeries{
+			Labels:  map[string]string{},
+			Samples: make([]*model.Sample, 0, len(protots.Samples)),
+		}
+		for _, pair := range protots.Labels {
+			ts.Labels[pair.Name] = pair.Value
+		}
+		for _, protosamp := range protots.Samples {
+			ts.Samples = append(ts.Samples, &model.Sample{
+				TimestampMS: protosamp.TimestampMs,
+				Value:       protosamp.Value,
+			})
+		}
+		tsb = append(tsb, ts)
+	}
+	return tsb, nil
+}

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 	vulcan.PersistentFlags().String("log-level", "info", "The level of logging (panic|fatal|error|warn|info|debug)")
 
 	vulcan.AddCommand(cmd.Indexer())
-	vulcan.AddCommand(cmd.Ingester)
+	vulcan.AddCommand(cmd.Ingester())
 	vulcan.AddCommand(cmd.Querier())
 	vulcan.AddCommand(cmd.Forwarder())
 

--- a/model/doc.go
+++ b/model/doc.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bus
-
-// Timestamp is the milliseconds since the unix epoch. We use this instead of go's time.Time
-// since prometheus expects time to be represented in this way, and this value is also more
-// natural for our data model.
-//
-// converting to a go time.Time value is simple: `time.Unix(t/1000, (ts%1000)*1000*1000))`
-// but does cost extra instructions when we do this for EVERY datapoint only to turn around
-// and turn it back into a int64 for prometheus query engine. Plus, dividing is an expensive
-// instruction.
-// Deprecated.
-type Timestamp int64
+/*
+Package model defines the common data types around TimeSeries that is re-used
+throughout Vulcan packages.
+*/
+package model

--- a/model/timeseries.go
+++ b/model/timeseries.go
@@ -1,0 +1,61 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+
+	"github.com/prometheus/common/model"
+)
+
+// Sample is a single value at a time.
+type Sample struct {
+	TimestampMS int64
+	Value       float64
+}
+
+// TimeSeries is an identifying set of labels and one or more samples.
+type TimeSeries struct {
+	Labels  map[string]string
+	Samples []*Sample
+}
+
+// Name returns the metric name for the TimeSeries stored as a special label.
+func (ts *TimeSeries) Name() string {
+	return ts.Labels[model.MetricNameLabel]
+}
+
+// ID is a consistent string based on the Labels of this TimeSeries that can
+// also be parsed to recreate the original Labels. For this, we use JSON and
+// leverage golang sorting map keys while marshalling to JSON:
+// https://github.com/golang/go/blob/release-branch.go1.7/src/encoding/json/encode.go#L121-L127
+func (ts *TimeSeries) ID() string {
+	b, err := json.Marshal(ts.Labels)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// TimeSeriesBatch is a group of TimeSeries that are processed together
+// for performance reasons.
+type TimeSeriesBatch []*TimeSeries
+
+// LabelsFromTimeSeriesID parses the Labels for a TimeSeries from a TimeSeries ID.
+func LabelsFromTimeSeriesID(id string) (map[string]string, error) {
+	l := map[string]string{}
+	err := json.Unmarshal([]byte(id), &l)
+	return l, err
+}


### PR DESCRIPTION
The ingester worker should be able to load balance Kafka messages between all active ingesters. This is done with Kafka Consumer Groups.

I wanted to bring our data structs more in-line with what we're now utilizing with the Prometheus generic remote storage API. The remote storage structs are simpler than the exposition format protobuf structs we were modeling in the `bus` package, though these structs still exist (for now). I commented the structs in the `bus` package as deprecated. The Indexer still relies on them (for now). 

I chose to avoid the `bus` package and make a new `model` package since these structs for `TimeSeries`, `Sample`, and `TimeSeriesBatch` are used in components that don't actually interact with the message bus.

The refactored ingester uses a new `kafka.Source` and a `cassandra.Writer` which makes use of the new model structs. The `kafka.AckSource` still exists for the indexer, but is commented as deprecated.

The `kafka.Source` utilizes a Kafka Consumer Group so that multiple ingester workers can load balance the Kafka messages of a topic.
