### PR TITLE
make publishing docker tags easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.7
+
 before_install:
   - go get github.com/golang/lint/golint
   - curl -fsSL https://github.com/Masterminds/glide/releases/download/v0.12.2/glide-v0.12.2-linux-amd64.tar.gz -o glide.tar.gz
@@ -12,7 +13,8 @@ script:
   - ./scripts/licensecheck.sh
   - make vet
   - make lint
-  - make
+  - make test
+  - make binary
 
 cache:
   directories:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox:glibc
+ 
+COPY target/linux/vulcan /usr/local/bin/vulcan
+ENTRYPOINT ["vulcan"]


### PR DESCRIPTION
This adds `make push` and `make docker` to the Makefile. This allows easier creation of runnable Vulcan containers available on docker hub (for those who have hub access to publish). For now, this pushes to the docker hub repo `dovulcan/vulcan`.

The goal is to make it easier to run Vulcan through docker while developing. `make docker` is still available to those without rights to publish to docker hub.

I was experimenting with having travis auto-build the docker container and push it, but was having issues with the containers being produced.