### PR TITLE
kafka: switch to async consumer & implement prom exporter

### DIFF
--- a/bus/writer.go
+++ b/bus/writer.go
@@ -18,5 +18,8 @@ import "github.com/prometheus/prometheus/storage/remote"
 
 // Writer is an interface that wraps the Write method to a message bus.
 type Writer interface {
+	// Write writes the timeseries data to the configured.
+	// The key can be used as a partition key to where the the paylad req
+	// should be written.
 	Write(key string, req *remote.WriteRequest) error
 }

--- a/cassandra/writer.go
+++ b/cassandra/writer.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/digitalocean/vulcan/model"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gocql/gocql"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -140,7 +139,6 @@ func (w *Writer) Write(tsb model.TimeSeriesBatch) error {
 }
 
 func (w *Writer) worker() {
-	ll := log.WithFields(log.Fields{"source": "cassandra.writer.worker"})
 
 	w.workerCount.WithLabelValues("idle").Inc()
 
@@ -152,14 +150,12 @@ func (w *Writer) worker() {
 			err := w.write(id, s.TimestampMS, s.Value)
 			if err != nil {
 				// send error back on payload's errch; don't block the worker
-				go ll.WithError(err).Error("write failed")
 
 				select {
 				case m.errch <- err:
 				default:
 				}
 			}
-			ll.WithFields(log.Fields{"sample": s.Value, "id": id}).Debug("sample written to cassandra")
 		}
 		m.wg.Done()
 		w.workerCount.WithLabelValues("idle").Inc()

--- a/cassandra/writer.go
+++ b/cassandra/writer.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"github.com/digitalocean/vulcan/model"
+
+	log "github.com/Sirupsen/logrus"
 	"github.com/gocql/gocql"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -138,7 +140,10 @@ func (w *Writer) Write(tsb model.TimeSeriesBatch) error {
 }
 
 func (w *Writer) worker() {
+	ll := log.WithFields(log.Fields{"source": "cassandra.writer.worker"})
+
 	w.workerCount.WithLabelValues("idle").Inc()
+
 	for m := range w.ch {
 		w.workerCount.WithLabelValues("idle").Dec()
 		w.workerCount.WithLabelValues("active").Inc()
@@ -147,11 +152,14 @@ func (w *Writer) worker() {
 			err := w.write(id, s.TimestampMS, s.Value)
 			if err != nil {
 				// send error back on payload's errch; don't block the worker
+				go ll.WithError(err).Error("write failed")
+
 				select {
 				case m.errch <- err:
 				default:
 				}
 			}
+			ll.WithFields(log.Fields{"sample": s.Value, "id": id}).Debug("sample written to cassandra")
 		}
 		m.wg.Done()
 		w.workerCount.WithLabelValues("idle").Inc()

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,0 +1,34 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+// Vulcan command line flag names.
+const (
+	flagAddress             = "address"
+	flagCassandraAddrs      = "cassandra-addrs"
+	flagCassandraKeyspace   = "cassandra-keyspace"
+	flagCassandraTimeout    = "cassandra-timeout"
+	flagCassandraNumConns   = "cassandra-num-conns"
+	flagKafkaAddrs          = "kafka-addrs"
+	flagKafkaClientID       = "kafka-client-id"
+	flagKafkaGroupID        = "kafka-group-id"
+	flagKafkaTopic          = "kafka-topic"
+	flagNumCassandraWorkers = "num-cassandra-workers"
+	flagNumKafkaWorkers     = "num-kafka-workers"
+	flagNumWorkers          = "num-workers"
+	flagTelemetryPath       = "telemetry-path"
+	flagWebListenAddress    = "web-listen-address"
+	flagKafkaTrackWrites    = "kafka-track-writes"
+)

--- a/cmd/forwarder.go
+++ b/cmd/forwarder.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"google.golang.org/grpc"
 
@@ -122,11 +121,12 @@ func Forwarder() *cobra.Command {
 
 			// listen for signals so can gracefully stop kakfa producer
 			go func() {
-				for _ = range signals {
-					w.Stop()
-					time.Sleep(2 * time.Second)
-					os.Exit(0)
-				}
+				<-signals
+				// tell forwarder to stop handling in incoming requests
+				fwd.Stop()
+				// tell kafka writer to stop sending out producer messages
+				w.Stop()
+				os.Exit(0)
 			}()
 
 			return <-errCh

--- a/cmd/forwarder.go
+++ b/cmd/forwarder.go
@@ -37,24 +37,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-const (
-	flagAddress             = "address"
-	flagCassandraAddrs      = "cassandra-addrs"
-	flagCassandraKeyspace   = "cassandra-keyspace"
-	flagCassandraTimeout    = "cassandra-timeout"
-	flagCassandraNumConns   = "cassandra-num-conns"
-	flagKafkaAddrs          = "kafka-addrs"
-	flagKafkaClientID       = "kafka-client-id"
-	flagKafkaGroupID        = "kafka-group-id"
-	flagKafkaTopic          = "kafka-topic"
-	flagNumCassandraWorkers = "num-cassandra-workers"
-	flagNumKafkaWorkers     = "num-kafka-workers"
-	flagNumWorkers          = "num-workers"
-	flagTelemetryPath       = "telemetry-path"
-	flagWebListenAddress    = "web-listen-address"
-	flagKafkaTrackWrites    = "kafka-track-writes"
-)
-
 // Forwarder handles parsing the command line options, initializes, and starts the
 // forwarder service accordingling.  It is the entry point for the forwarder
 // service.

--- a/cmd/forwarder.go
+++ b/cmd/forwarder.go
@@ -52,6 +52,7 @@ const (
 	flagNumWorkers          = "num-workers"
 	flagTelemetryPath       = "telemetry-path"
 	flagWebListenAddress    = "web-listen-address"
+	flagKafkaTrackWrites    = "kafka-track-writes"
 )
 
 // Forwarder handles parsing the command line options, initializes, and starts the
@@ -70,9 +71,10 @@ func Forwarder() *cobra.Command {
 			signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 			// create upstream kafka writer to receive data
 			w, err := kafka.NewWriter(&kafka.WriterConfig{
-				ClientID: viper.GetString(flagKafkaClientID),
-				Topic:    viper.GetString(flagKafkaTopic),
-				Addrs:    strings.Split(viper.GetString(flagKafkaAddrs), ","),
+				ClientID:    viper.GetString(flagKafkaClientID),
+				Topic:       viper.GetString(flagKafkaTopic),
+				Addrs:       strings.Split(viper.GetString(flagKafkaAddrs), ","),
+				TrackWrites: viper.GetBool(flagKafkaTrackWrites),
 			})
 			if err != nil {
 				return err
@@ -155,6 +157,7 @@ func Forwarder() *cobra.Command {
 	f.Flags().String(flagKafkaClientID, "vulcan-forwarder", "set the kafka client id")
 	f.Flags().String(flagTelemetryPath, "/metrics", "path under which to expose metrics")
 	f.Flags().String(flagWebListenAddress, ":9031", "address to listen on for telemetry")
+	f.Flags().Bool(flagKafkaTrackWrites, false, "track kafka writes for metric scraping and logging")
 
 	return f
 }

--- a/forwarder/writer_test.go
+++ b/forwarder/writer_test.go
@@ -17,7 +17,6 @@ package forwarder
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -871,8 +870,9 @@ func TestForwarderWrite(t *testing.T) {
 		// Not using any of the returned values currently
 		_, _ = f.Write(context.Background(), test.arg)
 
-		// give one second for mock go routines to complete
-		time.Sleep(1500 * time.Millisecond)
+		// wait for write calls to complete
+		f.wg.Done()
+		f.wg.Wait()
 
 		if mw.WriteCount != test.expectedWriteCount {
 			t.Errorf(

--- a/forwarder/writer_test.go
+++ b/forwarder/writer_test.go
@@ -17,6 +17,7 @@ package forwarder
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -869,6 +870,9 @@ func TestForwarderWrite(t *testing.T) {
 
 		// Not using any of the returned values currently
 		_, _ = f.Write(context.Background(), test.arg)
+
+		// give one second for mock go routines to complete
+		time.Sleep(1500 * time.Millisecond)
 
 		if mw.WriteCount != test.expectedWriteCount {
 			t.Errorf(

--- a/kafka/writer.go
+++ b/kafka/writer.go
@@ -52,6 +52,8 @@ func NewWriter(config *WriterConfig) (*Writer, error) {
 	cfg := sarama.NewConfig()
 	cfg.ClientID = config.ClientID
 	cfg.Producer.Compression = sarama.CompressionGZIP
+	cfg.Producer.Return.Successes = config.TrackWrites
+
 	producer, err := sarama.NewAsyncProducer(config.Addrs, cfg)
 	if err != nil {
 		return nil, err
@@ -91,9 +93,10 @@ func NewWriter(config *WriterConfig) (*Writer, error) {
 
 // WriterConfig represents the configuration of a Writer object.
 type WriterConfig struct {
-	ClientID string
-	Addrs    []string
-	Topic    string
+	ClientID    string
+	Addrs       []string
+	Topic       string
+	TrackWrites bool
 }
 
 // Describe implements prometheus.Collector which makes the forwarder


### PR DESCRIPTION
- Refactor kafka package to use an asynchronous Fafka client instead of the prior synchronous one to speed up the incoming data flow from prometheus to itself.
- Add prometheus gauge in Forwarder write to track the number of Timeseries objects sent per write request (removed logging in this area).  
- Implement the Kafka writer as a prometheus collector to track write successes and failures, and current enqueued messages.
- Handling of SIGINT and SIGTERM signals for gracefully shutdown of the Kafka Writer.
- Minor logging changes throughout the app.