### PR TITLE
ingester sets cassandra ttl on uncompressed samples

### DIFF
--- a/cassandra/writer.go
+++ b/cassandra/writer.go
@@ -79,7 +79,7 @@ func NewWriter(config *WriterConfig) *Writer {
 	w := &Writer{
 		s:          config.Session,
 		ch:         make(chan *writerPayload),
-		ttlSeconds: config.TTL.Nanoseconds() / int64(time.Second),
+		ttlSeconds: int64(config.TTL.Seconds()),
 
 		batchWriteDuration: prometheus.NewHistogram(
 			prometheus.HistogramOpts{

--- a/cmd/forwarder.go
+++ b/cmd/forwarder.go
@@ -48,6 +48,7 @@ const (
 	flagNumWorkers          = "num-workers"
 	flagTelemetryPath       = "telemetry-path"
 	flagWebListenAddress    = "web-listen-address"
+	flagUncompressedTTL     = "uncompressed-ttl"
 )
 
 // Forwarder handles parsing the command line options, initializes, and starts the

--- a/cmd/ingester.go
+++ b/cmd/ingester.go
@@ -49,6 +49,7 @@ func Ingester() *cobra.Command {
 			w := cassandra.NewWriter(&cassandra.WriterConfig{
 				NumWorkers: viper.GetInt(flagNumCassandraWorkers),
 				Session:    sess,
+				TTL:        viper.GetDuration(flagUncompressedTTL),
 			})
 			err = prometheus.Register(w)
 			if err != nil {
@@ -86,6 +87,7 @@ func Ingester() *cobra.Command {
 	ingcmd.Flags().String(flagKafkaClientID, "vulcan-ingest", "set the kafka client id")
 	ingcmd.Flags().String(flagKafkaGroupID, "vulcan-ingester", "workers with the same groupID will join the same Kafka ConsumerGroup")
 	ingcmd.Flags().String(flagKafkaTopic, "vulcan", "set the kafka topic to consume")
+	ingcmd.Flags().Duration(flagUncompressedTTL, time.Hour*24*7, "uncompressed sample ttl")
 
 	return ingcmd
 }


### PR DESCRIPTION
When samples are written to the Cassandra uncompressed table, they are now written with a configurable TTL (seven days by default). The goal is to have cheap/automatic cleanup of old data. The TTL on the uncompressed table should be enough of a window to have the (not-yet-implemented) compactors store 2-hour blocks of samples from the uncompressed table into the compressed table as a blob. 

Having a TTL right now before implementing the compactor allows us to cap the amount of disk we need for our cluster with a given ingest rate and ttl. The TTL can be set to `0s` for no TTL.