### PR TITLE
querier: read with token-aware driver

### DIFF
--- a/cmd/querier.go
+++ b/cmd/querier.go
@@ -21,6 +21,7 @@ import (
 	"github.com/digitalocean/vulcan/querier"
 	"github.com/digitalocean/vulcan/storage/elasticsearch"
 	"github.com/gocql/gocql"
+	hostpool "github.com/hailocab/go-hostpool"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -49,6 +50,13 @@ func Querier() *cobra.Command {
 			cluster.NumConns = viper.GetInt(flagCassandraNumConns)
 			cluster.Consistency = gocql.LocalOne
 			cluster.ProtoVersion = 4
+			// Fallback simple host pool distributes queries and prevents sending queries to unresponsive hosts.
+			fallbackHostPolicy := gocql.HostPoolHostPolicy(hostpool.New(nil))
+			// Token-aware policy performs queries against a host responsible for the partition.
+			// TODO in gocql make token-aware able to write to any host for a partition when the
+			// replication factor is > 1.
+			// https://github.com/gocql/gocql/blob/4f49cd01c8939ce7624952fe286c3d08c4be7fa1/policies.go#L331
+			cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(fallbackHostPolicy)
 			sess, err := cluster.CreateSession()
 			if err != nil {
 				return err


### PR DESCRIPTION
Like #67, setting the driver to be token-aware allows Vulcan to operate quicker since queries are directed to a Cassandra node that owns the data for the given query.