### PR TITLE
makefile: simpler; faster; fixes for lint and licensecheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _testmain.go
 *.test
 *.prof
 *.swp
+.makecache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,16 @@ go:
   - 1.7
 
 before_install:
+  # install golint
   - go get github.com/golang/lint/golint
+  # install glide
   - curl -fsSL https://github.com/Masterminds/glide/releases/download/v0.12.2/glide-v0.12.2-linux-amd64.tar.gz -o glide.tar.gz
   - echo "edd398b4e94116b289b9494d1c13ec2ea37386bad4ada91ecc9825f96b12143c  glide.tar.gz" | sha256sum -c -
   - tar -xf glide.tar.gz --strip-components=1 -C "$GOPATH/bin" linux-amd64/glide
   - rm glide.tar.gz
 
 script:
-  - ./scripts/licensecheck.sh
-  - make vet
-  - make lint
-  - make test
-  - make binary
+  - make release
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - rm glide.tar.gz
 
 script:
-  - make release
+  - make lint vet licensecheck test bin
 
 cache:
   directories:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM busybox:glibc
  
-COPY target/linux/vulcan /usr/local/bin/vulcan
+COPY target/vulcan_linux_amd64 /usr/local/bin/vulcan
 ENTRYPOINT ["vulcan"]

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,13 +20,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// VersionConfig is used to create a Version since the parameters are all
+// strings and easy to order wrong.
+type VersionConfig struct {
+	GitSummary string
+	GoVersion  string
+}
+
 // Version handles the command line option for the Vulcan version.
-func Version(hash, version string) *cobra.Command {
-	return &cobra.Command{
+func Version(config *VersionConfig) *cobra.Command {
+	v := &cobra.Command{
 		Use:   "version",
-		Short: "Print the version number of vulcan",
+		Short: "Version prints the Vulcan version.",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("hash=%s\nversion=%s\n", hash, version)
+			fmt.Printf("%s\n\nGitSummary: %s\nGoVersion: %s\n", config.GitSummary, config.GitSummary, config.GoVersion)
 		},
 	}
+	return v
 }

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ import (
 )
 
 var (
-	hash    string
-	version string
+	gitSummary string
+	goVersion  string
 )
 
 func main() {
@@ -63,7 +63,10 @@ func main() {
 	vulcan.AddCommand(cmd.Querier())
 	vulcan.AddCommand(cmd.Forwarder())
 
-	vulcan.AddCommand(cmd.Version(hash, version))
+	vulcan.AddCommand(cmd.Version(&cmd.VersionConfig{
+		GitSummary: gitSummary,
+		GoVersion:  goVersion,
+	}))
 
 	if err := vulcan.Execute(); err != nil {
 		log.Fatal(err)

--- a/scripts/licensecheck
+++ b/scripts/licensecheck
@@ -20,7 +20,7 @@ EndOfLicense
 
 # Scan each Go source file for license.
 EXIT=0
-GOFILES=$(find . -name "*.go")
+GOFILES=$(find . -name '*.go' -not -path './vendor/*')
 
 for FILE in $GOFILES; do
 	BLOCK=$(head -n 14 $FILE)


### PR DESCRIPTION
* sets build flags `gitSummary` and `goVersion`
* `vulcan vendor` displays git summary and go version set in makefile
* simplifies tar creation
* uses `.makefile/{vendor,docker}` touchfiles to do less work
* fixes licensecheck so it doesn't check vendor files
* fixes make lint so it doesn't check vendor files
* uses git summary everywhere instead of git short hash and git version
* git summary includes "-dirty" if running makefile with uncommitted changes