### PR TITLE
Indexer/use consumer group

### DIFF
--- a/cmd/indexer.go
+++ b/cmd/indexer.go
@@ -40,16 +40,15 @@ func Indexer() *cobra.Command {
 		Short: "consumes metrics from the bus and makes them searchable",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// get kafka source
-			source, err := kafka.NewAckSource(&kafka.AckSourceConfig{
-				Addrs:     strings.Split(viper.GetString("kafka-addrs"), ","),
-				ClientID:  viper.GetString("kafka-client-id"),
-				Converter: kafka.DefaultConverter{},
-				Topic:     viper.GetString("kafka-topic"),
+			s, err := kafka.NewSource(&kafka.SourceConfig{
+				Addrs:    strings.Split(viper.GetString(flagKafkaAddrs), ","),
+				ClientID: viper.GetString(flagKafkaClientID),
+				GroupID:  viper.GetString(flagKafkaGroupID),
+				Topics:   []string{viper.GetString(flagKafkaTopic)},
 			})
 			if err != nil {
 				return err
 			}
-			prometheus.MustRegister(source)
 
 			// set up elastic search templates for the type of text query we need to run
 			err = elasticsearch.SetupMatchTemplate(viper.GetString("es"))
@@ -90,7 +89,7 @@ func Indexer() *cobra.Command {
 			// create indexer and run
 			i := indexer.NewIndexer(&indexer.Config{
 				SampleIndexer:      sampleIndexer,
-				Source:             source,
+				Source:             s,
 				NumIndexGoroutines: viper.GetInt("indexer-goroutines"),
 			})
 			prometheus.MustRegister(i)
@@ -106,6 +105,7 @@ func Indexer() *cobra.Command {
 	Indexer.Flags().String("kafka-addrs", "", "one.example.com:9092,two.example.com:9092")
 	Indexer.Flags().String("kafka-client-id", "vulcan-indexer", "set the kafka client id")
 	Indexer.Flags().String("kafka-topic", "vulcan", "topic to read in kafka")
+	Indexer.Flags().String(flagKafkaGroupID, "vulcan-indexer", "workers with the same groupID will join the same Kafka ConsumerGroup")
 	Indexer.Flags().String("es", "http://elasticsearch:9200", "elasticsearch connection url")
 	Indexer.Flags().Bool("es-sniff", true, "whether or not to sniff additional hosts in the cluster")
 	Indexer.Flags().String("es-index", "vulcan", "the elasticsearch index to write documents into")

--- a/cmd/indexer.go
+++ b/cmd/indexer.go
@@ -78,9 +78,8 @@ func Indexer() *cobra.Command {
 
 			// set up caching es sample indexer
 			esIndexer := elasticsearch.NewSampleIndexer(&elasticsearch.SampleIndexerConfig{
-				Client:     client,
-				Index:      viper.GetString("es-index"),
-				NumWorkers: viper.GetInt("num-es-workers"),
+				Client: client,
+				Index:  viper.GetString("es-index"),
 			})
 			sampleIndexer := storage.NewCachingIndexer(&storage.CachingIndexerConfig{
 				Indexer:     esIndexer,
@@ -92,7 +91,6 @@ func Indexer() *cobra.Command {
 				SampleIndexer:      sampleIndexer,
 				Source:             s,
 				NumIndexGoroutines: viper.GetInt("indexer-goroutines"),
-				CleanUp:            esIndexer.Stop,
 			})
 
 			prometheus.MustRegister(i)
@@ -117,8 +115,7 @@ func Indexer() *cobra.Command {
 	Indexer.Flags().String("es-index", "vulcan", "the elasticsearch index to write documents into")
 	Indexer.Flags().Duration("es-writecache-duration", time.Minute*10, "the duration to cache having written a value to es and to skip further writes of the same metric")
 	Indexer.Flags().Uint("indexer-goroutines", 30, "worker goroutines for writing indexes")
-	Indexer.Flags().Uint("max-idle-conn", 2, "max idle connections for fetching from data storage")
-	Indexer.Flags().Uint("num-es-workers", 30, "number of workers to handle ES requests")
+	Indexer.Flags().Uint("max-idle-conn", 30, "max idle connections for fetching from data storage")
 
 	return Indexer
 }

--- a/elasticsearch/sample_indexer.go
+++ b/elasticsearch/sample_indexer.go
@@ -45,23 +45,18 @@ type SampleIndexer struct {
 	done   chan struct{}
 	once   *sync.Once
 
-	indexDurations      *prometheus.SummaryVec
-	indexBatchDurations prometheus.Histogram
-	workerCount         *prometheus.GaugeVec
-
-	// idle, active int
+	indexDurations *prometheus.SummaryVec
 }
 
 // SampleIndexerConfig represents the configuration of a SampleIndexer.
 type SampleIndexerConfig struct {
-	Client     *elastic.Client
-	NumWorkers int
-	Index      string
+	Client *elastic.Client
+	Index  string
 }
 
 // NewSampleIndexer creates a new instance of SampleIndexer.
 func NewSampleIndexer(config *SampleIndexerConfig) *SampleIndexer {
-	si := &SampleIndexer{
+	return &SampleIndexer{
 		Client: config.Client,
 		Index:  config.Index,
 
@@ -79,47 +74,19 @@ func NewSampleIndexer(config *SampleIndexerConfig) *SampleIndexer {
 			},
 			[]string{"mode"},
 		),
-		indexBatchDurations: prometheus.NewHistogram(
-			prometheus.HistogramOpts{
-				Namespace: namespace,
-				Subsystem: subsystem,
-				Name:      "indexbatch_duration_seconds",
-				Help:      "Duration of processing of an entire timeseries batch.",
-				Buckets:   prometheus.DefBuckets,
-			},
-		),
-		workerCount: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: namespace,
-				Subsystem: subsystem,
-				Name:      "es_worker_count",
-				Help:      "Count of workers for writing to ElasticSearch.",
-			},
-			[]string{"mode"},
-		),
 	}
-
-	for i := 0; i < config.NumWorkers; i++ {
-		go si.work()
-	}
-
-	return si
 }
 
 // Describe implements prometheus.Collector.  Sends decriptors of the
 // instance's indexDurations to the parameter ch.
 func (si *SampleIndexer) Describe(ch chan<- *prometheus.Desc) {
 	si.indexDurations.Describe(ch)
-	si.indexBatchDurations.Describe(ch)
-	si.workerCount.Describe(ch)
 }
 
 // Collect implements prometheus.Collector.  Sends metrics collected bu the
 // instance's indexDurations to the parameter ch.
 func (si *SampleIndexer) Collect(ch chan<- prometheus.Metric) {
 	si.indexDurations.Collect(ch)
-	si.indexBatchDurations.Collect(ch)
-	si.workerCount.Collect(ch)
 }
 
 func metricToESBody(ts *model.TimeSeries) (map[string]string, error) {
@@ -132,43 +99,9 @@ func metricToESBody(ts *model.TimeSeries) (map[string]string, error) {
 	return labels, nil
 }
 
-// IndexSample implements the SampleIndexer interface.
-// It waits for either the work channel to accept the index request or
-// and a receive from the error channel.
+// IndexSample checks if a metric label set exists in the database, if not
+// it writes the label set.
 func (si *SampleIndexer) IndexSample(ts *model.TimeSeries) error {
-	// check if there is an error first
-	select {
-	case err := <-si.errCh:
-		return err
-
-	default:
-	}
-
-	// block until one of these complete
-	select {
-	case si.workCh <- ts:
-		return nil
-
-	case err := <-si.errCh:
-		return err
-	}
-}
-
-// IndexSamples indexes a model.TimeSeriesBatch
-func (si *SampleIndexer) IndexSamples(tsb model.TimeSeriesBatch) error {
-	t0 := time.Now()
-	defer si.indexBatchDurations.Observe(time.Since(t0).Seconds())
-
-	for _, ts := range tsb {
-		if err := si.IndexSample(ts); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (si *SampleIndexer) indexSample(ts *model.TimeSeries) error {
 	t0 := time.Now()
 
 	exists, err := si.Client.Exists().
@@ -200,36 +133,4 @@ func (si *SampleIndexer) indexSample(ts *model.TimeSeries) error {
 
 	si.indexDurations.WithLabelValues("insert").Observe(time.Since(t0).Seconds())
 	return nil
-}
-
-// work is a routine that handles the actual communicaiton with ElasticSearch.
-// As currently implemented, it does stops all current goroutines:
-func (si *SampleIndexer) work() {
-	for {
-		si.workerCount.WithLabelValues("idle").Inc()
-		select {
-		case ts := <-si.workCh:
-			si.workerCount.WithLabelValues("idle").Dec()
-			si.workerCount.WithLabelValues("active").Inc()
-
-			if err := si.indexSample(ts); err != nil {
-				select {
-				case si.errCh <- err:
-				default:
-				}
-			}
-
-			si.workerCount.WithLabelValues("active").Dec()
-
-		case <-si.done:
-			return
-		}
-	}
-}
-
-// Stop stops all worker goroutines.
-func (si *SampleIndexer) Stop() {
-	si.once.Do(func() {
-		close(si.done)
-	})
 }

--- a/elasticsearch/sample_indexer.go
+++ b/elasticsearch/sample_indexer.go
@@ -15,6 +15,7 @@
 package elasticsearch
 
 import (
+	"sync"
 	"time"
 
 	"github.com/digitalocean/vulcan/convert"
@@ -39,21 +40,36 @@ type SampleIndexer struct {
 	Client *elastic.Client
 	Index  string
 
+	workCh chan *model.TimeSeries
+	errCh  chan error
+	done   chan struct{}
+	once   *sync.Once
+
 	indexDurations      *prometheus.SummaryVec
 	indexBatchDurations prometheus.Histogram
+	workerCount         *prometheus.GaugeVec
+
+	// idle, active int
 }
 
 // SampleIndexerConfig represents the configuration of a SampleIndexer.
 type SampleIndexerConfig struct {
-	Client *elastic.Client
-	Index  string
+	Client     *elastic.Client
+	NumWorkers int
+	Index      string
 }
 
 // NewSampleIndexer creates a new instance of SampleIndexer.
 func NewSampleIndexer(config *SampleIndexerConfig) *SampleIndexer {
-	return &SampleIndexer{
+	si := &SampleIndexer{
 		Client: config.Client,
 		Index:  config.Index,
+
+		workCh: make(chan *model.TimeSeries, 1),
+		errCh:  make(chan error),
+		done:   make(chan struct{}),
+		once:   new(sync.Once),
+
 		indexDurations: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
 				Namespace: namespace,
@@ -72,7 +88,22 @@ func NewSampleIndexer(config *SampleIndexerConfig) *SampleIndexer {
 				Buckets:   prometheus.DefBuckets,
 			},
 		),
+		workerCount: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "es_worker_count",
+				Help:      "Count of workers for writing to ElasticSearch.",
+			},
+			[]string{"mode"},
+		),
 	}
+
+	for i := 0; i < config.NumWorkers; i++ {
+		go si.work()
+	}
+
+	return si
 }
 
 // Describe implements prometheus.Collector.  Sends decriptors of the
@@ -80,6 +111,7 @@ func NewSampleIndexer(config *SampleIndexerConfig) *SampleIndexer {
 func (si *SampleIndexer) Describe(ch chan<- *prometheus.Desc) {
 	si.indexDurations.Describe(ch)
 	si.indexBatchDurations.Describe(ch)
+	si.workerCount.Describe(ch)
 }
 
 // Collect implements prometheus.Collector.  Sends metrics collected bu the
@@ -87,6 +119,7 @@ func (si *SampleIndexer) Describe(ch chan<- *prometheus.Desc) {
 func (si *SampleIndexer) Collect(ch chan<- prometheus.Metric) {
 	si.indexDurations.Collect(ch)
 	si.indexBatchDurations.Collect(ch)
+	si.workerCount.Collect(ch)
 }
 
 func metricToESBody(ts *model.TimeSeries) (map[string]string, error) {
@@ -100,16 +133,48 @@ func metricToESBody(ts *model.TimeSeries) (map[string]string, error) {
 }
 
 // IndexSample implements the SampleIndexer interface.
+// It waits for either the work channel to accept the index request or
+// and a receive from the error channel.
 func (si *SampleIndexer) IndexSample(ts *model.TimeSeries) error {
-	var (
-		t0  = time.Now()
-		key = ts.ID()
-	)
+	// check if there is an error first
+	select {
+	case err := <-si.errCh:
+		return err
+
+	default:
+	}
+
+	// block until one of these complete
+	select {
+	case si.workCh <- ts:
+		return nil
+
+	case err := <-si.errCh:
+		return err
+	}
+}
+
+// IndexSamples indexes a model.TimeSeriesBatch
+func (si *SampleIndexer) IndexSamples(tsb model.TimeSeriesBatch) error {
+	t0 := time.Now()
+	defer si.indexBatchDurations.Observe(time.Since(t0).Seconds())
+
+	for _, ts := range tsb {
+		if err := si.IndexSample(ts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (si *SampleIndexer) indexSample(ts *model.TimeSeries) error {
+	t0 := time.Now()
 
 	exists, err := si.Client.Exists().
 		Index(si.Index).
 		Type("sample").
-		Id(key).Do()
+		Id(ts.ID()).Do()
 	if err != nil {
 		return err
 	}
@@ -126,25 +191,45 @@ func (si *SampleIndexer) IndexSample(ts *model.TimeSeries) error {
 	_, err = si.Client.Index().
 		Index(si.Index).
 		Type("sample").
-		Id(key).
+		Id(ts.ID()).
 		BodyJson(body).
 		Do()
-	si.indexDurations.WithLabelValues("insert").Observe(time.Since(t0).Seconds())
-
-	return err
-}
-
-// IndexSamples indexes a model.TimeSeriesBatch
-func (si *SampleIndexer) IndexSamples(tsb model.TimeSeriesBatch) error {
-	t0 := time.Now()
-
-	defer si.indexBatchDurations.Observe(time.Since(t0).Seconds())
-
-	for _, ts := range tsb {
-		if err := si.IndexSample(ts); err != nil {
-			return err
-		}
+	if err != nil {
+		return err
 	}
 
+	si.indexDurations.WithLabelValues("insert").Observe(time.Since(t0).Seconds())
 	return nil
+}
+
+// work is a routine that handles the actual communicaiton with ElasticSearch.
+// As currently implemented, it does stops all current goroutines:
+func (si *SampleIndexer) work() {
+	for {
+		si.workerCount.WithLabelValues("idle").Inc()
+		select {
+		case ts := <-si.workCh:
+			si.workerCount.WithLabelValues("idle").Dec()
+			si.workerCount.WithLabelValues("active").Inc()
+
+			if err := si.indexSample(ts); err != nil {
+				select {
+				case si.errCh <- err:
+				default:
+				}
+			}
+
+			si.workerCount.WithLabelValues("active").Dec()
+
+		case <-si.done:
+			return
+		}
+	}
+}
+
+// Stop stops all worker goroutines.
+func (si *SampleIndexer) Stop() {
+	si.once.Do(func() {
+		close(si.done)
+	})
 }

--- a/indexer/sampleindexer.go
+++ b/indexer/sampleindexer.go
@@ -14,15 +14,11 @@
 
 package indexer
 
-import (
-	"github.com/digitalocean/vulcan/model"
-	"github.com/prometheus/client_golang/prometheus"
-)
+import "github.com/digitalocean/vulcan/model"
 
 // SampleIndexer is an interface is provided to the indexer in order to index
 // metrics
 type SampleIndexer interface {
-	prometheus.Collector
 	// IndexSample takes in a sample from the message bus and makes indexing
 	// decisions on the target indexing system.
 	IndexSamples(model.TimeSeriesBatch) error

--- a/indexer/sampleindexer.go
+++ b/indexer/sampleindexer.go
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package indexer
 
 import (
-	"github.com/digitalocean/vulcan/bus"
-
+	"github.com/digitalocean/vulcan/model"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -26,5 +25,6 @@ type SampleIndexer interface {
 	prometheus.Collector
 	// IndexSample takes in a sample from the message bus and makes indexing
 	// decisions on the target indexing system.
-	IndexSample(*bus.Sample) error
+	IndexSamples(model.TimeSeriesBatch) error
+	IndexSample(*model.TimeSeries) error
 }

--- a/indexer/sampleindexer.go
+++ b/indexer/sampleindexer.go
@@ -21,6 +21,5 @@ import "github.com/digitalocean/vulcan/model"
 type SampleIndexer interface {
 	// IndexSample takes in a sample from the message bus and makes indexing
 	// decisions on the target indexing system.
-	IndexSamples(model.TimeSeriesBatch) error
 	IndexSample(*model.TimeSeries) error
 }

--- a/model/errors.go
+++ b/model/errors.go
@@ -12,19 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package model
 
-import (
-	"github.com/digitalocean/vulcan/bus"
+import "fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-)
+// Errors represents a slice of errors.
+// It implements the error interface and is meant to collect errors for
+// reporting reason.  It should not be use in a scenario where a single
+// error needs to trigger a failure.
+type Errors []error
 
-// SampleIndexer is an interface is provided to the indexer in order to index
-// metrics
-type SampleIndexer interface {
-	prometheus.Collector
-	// IndexSample takes in a sample from the message bus and makes indexing
-	// decisions on the target indexing system.
-	IndexSample(*bus.Sample) error
+func (e Errors) Error() string {
+	if len(e) == 1 {
+		return e.Error()
+	}
+
+	msg := "multiple errors occured:"
+	for _, err := range e {
+		msg += fmt.Sprintf("\n%s", err.Error())
+	}
+
+	return msg
+}
+
+// Occurred checks if at least one 1 has occurred.
+func (e Errors) Occurred() bool {
+	return len(e) > 0
 }

--- a/storage/caching_indexer.go
+++ b/storage/caching_indexer.go
@@ -18,29 +18,36 @@ import (
 	"sync"
 	"time"
 
-	"github.com/digitalocean/vulcan/bus"
-	"github.com/digitalocean/vulcan/convert"
+	"github.com/digitalocean/vulcan/indexer"
+	"github.com/digitalocean/vulcan/model"
 
 	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	namespace = "vulcan"
+	subsystem = "caching_indexer"
 )
 
 // CachingIndexer remembers when a metric was indexed last, if it is beyond
 // a provided duration, then the provided Writer is called to write the
 // metric and the time of the write is stored in CachingIndexer.
 type CachingIndexer struct {
-	SampleIndexer
+	indexer.SampleIndexer
+	prometheus.Collector
 
-	Indexer     SampleIndexer
+	Indexer     indexer.SampleIndexer
 	LastSeen    map[string]time.Time
 	MaxDuration time.Duration
 	m           sync.RWMutex
 
-	indexDurations *prometheus.SummaryVec
+	indexDurations      *prometheus.SummaryVec
+	indexBatchDurations prometheus.Histogram
 }
 
 // CachingIndexerConfig represents the configuration of a CachingIndexer object.
 type CachingIndexerConfig struct {
-	Indexer     SampleIndexer
+	Indexer     indexer.SampleIndexer
 	MaxDuration time.Duration
 }
 
@@ -52,12 +59,21 @@ func NewCachingIndexer(config *CachingIndexerConfig) *CachingIndexer {
 		MaxDuration: config.MaxDuration,
 		indexDurations: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
-				Namespace: "vulcan",
-				Subsystem: "caching_indexer",
-				Name:      "duration_nanoseconds",
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "duration_seconds",
 				Help:      "Durations of different caching_indexer stages",
 			},
 			[]string{"stage", "cache"},
+		),
+		indexBatchDurations: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "indexbatch_duration_seconds",
+				Help:      "Duration of processing of an entire timeseries batch.",
+				Buckets:   prometheus.DefBuckets,
+			},
 		),
 	}
 }
@@ -67,6 +83,7 @@ func NewCachingIndexer(config *CachingIndexerConfig) *CachingIndexer {
 func (ci *CachingIndexer) Describe(ch chan<- *prometheus.Desc) {
 	ci.indexDurations.Describe(ch)
 	ci.Indexer.Describe(ch)
+	ci.indexBatchDurations.Describe(ch)
 }
 
 // Collect implements Collector.  Sends metrics collected by indexDurations
@@ -74,34 +91,55 @@ func (ci *CachingIndexer) Describe(ch chan<- *prometheus.Desc) {
 func (ci *CachingIndexer) Collect(ch chan<- prometheus.Metric) {
 	ci.indexDurations.Collect(ch)
 	ci.Indexer.Collect(ch)
+	ci.indexBatchDurations.Collect(ch)
 }
 
-// IndexSample indexes the sample s if the sample s was not already indexed
-// within the set MaxDuration.
-func (ci *CachingIndexer) IndexSample(s *bus.Sample) error {
-	return ci.indexSample(s, time.Now())
-}
-
-func (ci *CachingIndexer) indexSample(s *bus.Sample, at time.Time) error {
+// IndexSamples checks a entire timeseries batch to see if the samples are
+// indexed.
+func (ci *CachingIndexer) IndexSamples(tsb model.TimeSeriesBatch) error {
 	t0 := time.Now()
-	key, err := convert.MetricToKey(s.Metric)
-	if err != nil {
-		return err
+
+	for _, ts := range tsb {
+		if err := ci.IndexSample(ts); err != nil {
+			return err
+		}
 	}
+	ci.indexBatchDurations.Observe(time.Since(t0).Seconds())
+
+	return nil
+}
+
+// IndexSample indexes the sample ts if the sample ts was not already indexed
+// within the set MaxDuration.
+func (ci *CachingIndexer) IndexSample(ts *model.TimeSeries) error {
+	return ci.indexSample(ts, time.Now())
+}
+
+func (ci *CachingIndexer) indexSample(ts *model.TimeSeries, at time.Time) error {
+	key := ts.ID()
+
 	ci.m.RLock()
 	last, ok := ci.LastSeen[key]
 	ci.m.RUnlock()
 	if ok && at.Sub(last) < ci.MaxDuration {
-		ci.indexDurations.WithLabelValues("index_sample", "hit").Observe(float64(time.Since(t0).Nanoseconds()))
+		ci.indexDurations.WithLabelValues("index_sample", "hit").Observe(
+			time.Since(at).Seconds(),
+		)
+
 		return nil
 	}
-	err = ci.Indexer.IndexSample(s)
-	if err != nil {
+
+	if err := ci.Indexer.IndexSample(ts); err != nil {
 		return err
 	}
+
 	ci.m.Lock()
 	ci.LastSeen[key] = at
 	ci.m.Unlock()
-	ci.indexDurations.WithLabelValues("index_sample", "miss").Observe(float64(time.Since(t0).Nanoseconds()))
+
+	ci.indexDurations.WithLabelValues("index_sample", "miss").Observe(
+		float64(time.Since(at).Seconds()),
+	)
+
 	return nil
 }

--- a/storage/caching_indexer.go
+++ b/storage/caching_indexer.go
@@ -82,7 +82,6 @@ func NewCachingIndexer(config *CachingIndexerConfig) *CachingIndexer {
 // instance's indexDurations and Indexer to the parameter ch.
 func (ci *CachingIndexer) Describe(ch chan<- *prometheus.Desc) {
 	ci.indexDurations.Describe(ch)
-	ci.Indexer.Describe(ch)
 	ci.indexBatchDurations.Describe(ch)
 }
 
@@ -90,7 +89,6 @@ func (ci *CachingIndexer) Describe(ch chan<- *prometheus.Desc) {
 // and Indexer to the parameter ch.
 func (ci *CachingIndexer) Collect(ch chan<- prometheus.Metric) {
 	ci.indexDurations.Collect(ch)
-	ci.Indexer.Collect(ch)
 	ci.indexBatchDurations.Collect(ch)
 }
 
@@ -98,13 +96,13 @@ func (ci *CachingIndexer) Collect(ch chan<- prometheus.Metric) {
 // indexed.
 func (ci *CachingIndexer) IndexSamples(tsb model.TimeSeriesBatch) error {
 	t0 := time.Now()
+	defer ci.indexBatchDurations.Observe(time.Since(t0).Seconds())
 
 	for _, ts := range tsb {
 		if err := ci.IndexSample(ts); err != nil {
 			return err
 		}
 	}
-	ci.indexBatchDurations.Observe(time.Since(t0).Seconds())
 
 	return nil
 }


### PR DESCRIPTION
- implementation of indexer to use kafka consumer groups
- note: left the 'errors_total' counter from prometheus scraping in pkg indexer for the time being since the current implementation of service exiting on the first encountered error ATM considered temporary.  