### PR TITLE
kafka: snappy compression for producer messages

### DIFF
--- a/kafka/writer.go
+++ b/kafka/writer.go
@@ -47,7 +47,7 @@ type Writer struct {
 func NewWriter(config *WriterConfig) (*Writer, error) {
 	cfg := sarama.NewConfig()
 	cfg.ClientID = config.ClientID
-	cfg.Producer.Compression = sarama.CompressionGZIP
+	cfg.Producer.Compression = sarama.CompressionSnappy
 	cfg.Producer.Return.Successes = config.TrackWrites
 	cfg.Producer.Flush.Bytes = config.BatchSize
 


### PR DESCRIPTION
- switch to Snappy compression from GZIP to alleviate some of the CPU overhead put on the ingester required for decompression.