### PR TITLE
cacher: in-memory metrics

### DIFF
--- a/cacher/accumulator.go
+++ b/cacher/accumulator.go
@@ -63,7 +63,7 @@ func NewAccumulator(cfg *AccumulatorConfig) (*Accumulator, error) {
 	return a, nil
 }
 
-// Append appends a sample to the accumulator. If this causes
+// Append appends a sample to the accumulator.
 func (a *Accumulator) Append(sample *model.Sample) error {
 	a.m.Lock()
 	defer a.m.Unlock()

--- a/cacher/accumulator.go
+++ b/cacher/accumulator.go
@@ -1,0 +1,142 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cacher
+
+import (
+	"sync"
+	"time"
+
+	"github.com/digitalocean/vulcan/model"
+	pmodel "github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/local/chunk"
+)
+
+// AccumulatorConfig is used to create a new Accumulator.
+type AccumulatorConfig struct {
+	MaxAge time.Duration
+}
+
+type chunkend struct {
+	Chunk chunk.Chunk
+	End   int64
+}
+
+// Accumulator collects samples for a single metric and calls a provided flush
+// function when the internal data structure has reached a maximum size limit,
+// or the time elapsed between the first and most recent sample exceeds a provided
+// maximum, or the time elapsed from making the accumulator dirty to now exceeds
+// a provided maximum.
+type Accumulator struct {
+	chunks []*chunkend
+	m      sync.Mutex
+	maxAge int64
+}
+
+// NewAccumulator creates an accumulator that will call Flush when it needs to
+// based on size and timing constraints.
+func NewAccumulator(cfg *AccumulatorConfig) (*Accumulator, error) {
+	c, err := chunk.NewForEncoding(chunk.Varbit)
+	if err != nil {
+		return nil, err
+	}
+	a := &Accumulator{
+		chunks: []*chunkend{
+			&chunkend{
+				Chunk: c,
+				End:   0,
+			},
+		},
+		maxAge: cfg.MaxAge.Nanoseconds() / int64(time.Millisecond),
+	}
+	return a, nil
+}
+
+// Append appends a sample to the accumulator. If this causes
+func (a *Accumulator) Append(sample *model.Sample) error {
+	a.m.Lock()
+	defer a.m.Unlock()
+	if sample.TimestampMS < a.chunks[0].End {
+		return nil
+	}
+	chunks, err := a.chunks[0].Chunk.Add(pmodel.SamplePair{
+		Timestamp: pmodel.Time(sample.TimestampMS),
+		Value:     pmodel.SampleValue(sample.Value),
+	})
+	if err != nil {
+		return err
+	}
+	switch len(chunks) {
+	case 1:
+		a.chunks[0].Chunk = chunks[0]
+		a.chunks[0].End = sample.TimestampMS
+	case 2:
+		// the end value of the just-overflowed-chunk is still valid.
+		a.chunks[0].Chunk = chunks[0]
+		next, err := chunk.NewForEncoding(chunk.Varbit)
+		if err != nil {
+			return err
+		}
+		// write overflow samples to new chunk
+		iter := chunks[1].NewIterator()
+		for iter.Scan() {
+			chunks, err := next.Add(iter.Value())
+			if err != nil {
+				return err
+			}
+			if len(chunks) != 1 {
+				panic("expected overflow samples to fit into new varbit chunk")
+			}
+			next = chunks[0]
+		}
+		// prepend
+		a.chunks = append([]*chunkend{
+			{
+				Chunk: next,
+				End:   sample.TimestampMS,
+			},
+		}, a.chunks...)
+	default:
+		panic("appending a sample to a chunk without error should always result in 1 or 2 elements in chunk slice")
+	}
+	// remove expired chunks
+	cutoff := sample.TimestampMS - a.maxAge
+	for len(a.chunks) > 0 {
+		end := a.chunks[len(a.chunks)-1].End
+		if end == 0 || end >= cutoff {
+			break
+		}
+		a.chunks = a.chunks[:len(a.chunks)-1]
+	}
+	return nil
+}
+
+// ChunksAfter returns a clone of all chunks in-time-ascending-order which contain
+// at least one value after the provided time. The result may be a length zero slice.
+func (a *Accumulator) ChunksAfter(after int64) []chunk.Chunk {
+	chunks := make([]chunk.Chunk, 0)
+	a.m.Lock()
+	defer a.m.Unlock()
+	for i := len(a.chunks) - 1; i >= 0; i-- {
+		if a.chunks[i].End > after {
+			chunks = append(chunks, a.chunks[i].Chunk.Clone())
+		}
+	}
+	return chunks
+}
+
+// Last returns the last appended timestamp in ms.
+func (a *Accumulator) Last() int64 {
+	return a.chunks[0].End
+}

--- a/cacher/accumulator_test.go
+++ b/cacher/accumulator_test.go
@@ -1,0 +1,142 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cacher_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/digitalocean/vulcan/cacher"
+	"github.com/digitalocean/vulcan/model"
+	pmodel "github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/local/chunk"
+)
+
+func makeFullChunk(start time.Time) (c chunk.Chunk, end time.Time, err error) {
+	var value float64
+	c, err = chunk.NewForEncoding(chunk.Varbit)
+	if err != nil {
+		return
+	}
+	chunks := []chunk.Chunk{c}
+	for len(chunks) < 2 {
+		// increment time by 15s + [0,1]μs for some variation
+		start = start.Add(time.Second*15 + time.Duration(rand.Int63n(int64(time.Microsecond))))
+		innerChunks, err := chunks[0].Add(pmodel.SamplePair{
+			Timestamp: pmodel.Time(start.UnixNano() / int64(time.Millisecond)),
+			Value:     pmodel.SampleValue(value),
+		})
+		if err != nil {
+			return c, end, err
+		}
+		chunks = innerChunks
+	}
+	return chunks[0], start, nil
+}
+
+func chunkEquals(c1, c2 chunk.Chunk) bool {
+	i1 := c1.NewIterator()
+	i2 := c2.NewIterator()
+	for i1.Scan() {
+		ok := i2.Scan()
+		if !ok {
+			return false
+		}
+		v1 := i1.Value()
+		v2 := i2.Value()
+		if !v1.Equal(&v2) {
+			return false
+		}
+	}
+	// if i2 can still scan, not equal
+	return !i2.Scan()
+}
+
+func TestAccumulator(t *testing.T) {
+	const longForm = "Jan 2, 2006 at 3:04pm (MST)"
+	start, err := time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	full1, end1, err := makeFullChunk(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	full2, _, err := makeFullChunk(end1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Run("acc", func(t *testing.T) {
+		t.Run("equals", func(t *testing.T) {
+			t.Parallel()
+			if !chunkEquals(full1, full1) {
+				t.Fatalf("expected full to eq full")
+			}
+		})
+		t.Run("size", func(t *testing.T) {
+			t.Parallel()
+			// this tests that the accumulator calls flush after a max internal size is reached.
+			full1 := full1.Clone()
+			full2 := full2.Clone()
+			a, err := cacher.NewAccumulator(&cacher.AccumulatorConfig{
+				MaxAge: time.Hour * 24 * 365,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			chunks := a.ChunksAfter(0)
+			if len(chunks) != 0 {
+				t.Errorf("expected len chunks to be %d but got %d", 0, len(chunks))
+			}
+			iter := full1.NewIterator()
+			for iter.Scan() {
+				v := iter.Value()
+				s := model.Sample{
+					TimestampMS: int64(v.Timestamp),
+					Value:       float64(v.Value),
+				}
+				err = a.Append(&s)
+				if err != nil {
+					t.Fatal(err)
+				}
+				chunks := a.ChunksAfter(0)
+				if len(chunks) != 1 {
+					t.Errorf("expected len chunks to be %d but got %d", 1, len(chunks))
+				}
+			}
+			iter = full2.NewIterator()
+			for iter.Scan() {
+				v := iter.Value()
+				s := model.Sample{
+					TimestampMS: int64(v.Timestamp),
+					Value:       float64(v.Value),
+				}
+				err = a.Append(&s)
+				if err != nil {
+					t.Fatal(err)
+				}
+				chunks := a.ChunksAfter(end1.UnixNano() / int64(time.Millisecond))
+				if len(chunks) != 1 {
+					t.Errorf("expected len chunks to be %d but got %d", 1, len(chunks))
+				}
+				chunks = a.ChunksAfter(0)
+				if len(chunks) != 2 {
+					t.Errorf("expected len chunks to be %d but got %d", 2, len(chunks))
+				}
+			}
+		})
+	})
+}

--- a/cacher/cacher.go
+++ b/cacher/cacher.go
@@ -1,0 +1,304 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cacher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/Sirupsen/logrus"
+	"github.com/digitalocean/vulcan/kafka"
+	"github.com/digitalocean/vulcan/model"
+	"github.com/golang/protobuf/proto"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/storage/local/chunk"
+	"github.com/prometheus/prometheus/storage/remote"
+	cg "github.com/supershabam/sarama-cg"
+	cgconsumer "github.com/supershabam/sarama-cg/consumer"
+)
+
+// Config is necessary for creating a new Cacher.
+type Config struct {
+	Cleanup     time.Duration
+	Client      sarama.Client
+	Coordinator *cg.Coordinator
+	MaxAge      time.Duration
+	Topic       string
+}
+
+type consumer struct {
+	Accs map[string]*Accumulator
+	M    sync.RWMutex
+}
+
+// Cacher is an idea to run an in-memory kafka consumer of varbit compressed metrics
+// and expose that data to the querier.
+type Cacher struct {
+	cfg           *Config
+	consumers     map[int32]*consumer
+	m             sync.RWMutex
+	numPartitions int
+	samplesTotal  *prometheus.CounterVec
+}
+
+// NewCacher creates but doesn't start a Cacher. Call Run to begin.
+func NewCacher(cfg *Config) (*Cacher, error) {
+	partitions, err := cfg.Client.Partitions(cfg.Topic)
+	if err != nil {
+		return nil, err
+	}
+	return &Cacher{
+		cfg:           cfg,
+		consumers:     map[int32]*consumer{},
+		numPartitions: len(partitions),
+		samplesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "vulcan",
+			Subsystem: "cacher",
+			Name:      "samples_total",
+			Help:      "count of samples ingested into cacher",
+		}, []string{"topic", "partition"}),
+	}, nil
+}
+
+// Describe implements prometheus.Collector.
+func (c *Cacher) Describe(ch chan<- *prometheus.Desc) {
+	c.samplesTotal.Describe(ch)
+}
+
+// Collect implements prometheus.Collector.
+func (c *Cacher) Collect(ch chan<- prometheus.Metric) {
+	c.samplesTotal.Collect(ch)
+}
+
+// ServeHTTP allows the cacher to be attached to an http server.
+func (c *Cacher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	chunks, err := c.ChunksAfter(id, time.Now().Add(-time.Hour*24*365).UnixNano()/int64(time.Millisecond))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp := &chunksResp{}
+	for _, chnk := range chunks {
+		buf := make([]byte, chunk.ChunkLen)
+		err := chnk.MarshalToBuf(buf)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		resp.Chunks = append(resp.Chunks, buf)
+	}
+	w.Header().Add("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	err = enc.Encode(resp)
+	if err != nil {
+		logrus.WithError(err).Info("while encoding response to client")
+	}
+}
+
+// ChunksAfter returns the chunks for the given id that occur after the provided unix timestamp in ms.
+func (c *Cacher) ChunksAfter(id string, after int64) ([]chunk.Chunk, error) {
+	labels, err := model.LabelsFromTimeSeriesID(id)
+	if err != nil {
+		return nil, err
+	}
+	key := kafka.Key(kafka.Job(labels["job"]), kafka.Instance(labels["instance"]))
+	p := kafka.HashNegativeAndReflectInsanity(key, c.numPartitions)
+	c.m.RLock()
+	cons, ok := c.consumers[p]
+	c.m.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+	cons.M.RLock()
+	acc, ok := cons.Accs[id]
+	cons.M.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+	return acc.ChunksAfter(after), nil
+}
+
+func (c *Cacher) consume(ctx context.Context, topic string, partition int32) error {
+	cons := &consumer{
+		Accs: map[string]*Accumulator{},
+	}
+	c.m.Lock()
+	c.consumers[partition] = cons
+	c.m.Unlock()
+	defer func() {
+		c.m.Lock()
+		delete(c.consumers, partition)
+		c.m.Unlock()
+	}()
+	partitionStr := fmt.Sprintf("%d", partition)
+	twc, err := cgconsumer.NewTimeWindow(&cgconsumer.TimeWindowConfig{
+		CacheDuration: time.Minute,
+		Client:        c.cfg.Client,
+		Context:       ctx,
+		Coordinator:   c.cfg.Coordinator,
+		Start:         cgconsumer.OffsetNewest,
+		Partition:     partition,
+		Topic:         topic,
+		Window:        c.cfg.MaxAge,
+	})
+	if err != nil {
+		return err
+	}
+	go func() {
+		gc := time.NewTicker(c.cfg.Cleanup)
+		defer gc.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-gc.C:
+				cutoff := time.Now().Add(-c.cfg.MaxAge).UnixNano() / int64(time.Millisecond)
+				// buffer of oldids to remove later with the write lock.
+				oldids := make([]string, 0, 1000)
+				cons.M.RLock()
+				for id, acc := range cons.Accs {
+					if acc.Last() < cutoff {
+						oldids = append(oldids, id)
+					}
+				}
+				cons.M.RUnlock()
+				if len(oldids) == 0 {
+					continue
+				}
+				cons.M.Lock()
+				for _, id := range oldids {
+					if acc, ok := cons.Accs[id]; ok && acc.Last() < cutoff {
+						delete(cons.Accs, id)
+					}
+				}
+				cons.M.Unlock()
+			}
+		}
+	}()
+	for msg := range twc.Consume() {
+		tsb, err := parseTimeSeriesBatch(msg.Value)
+		if err != nil {
+			return err
+		}
+		for _, ts := range tsb {
+			id := ts.ID()
+			// attempt to get existing accumulator with just read lock.
+			cons.M.RLock()
+			acc, ok := cons.Accs[id]
+			cons.M.RUnlock()
+			if !ok {
+				// create an accumulator and try to set it.
+				myacc, err := NewAccumulator(&AccumulatorConfig{
+					MaxAge: c.cfg.MaxAge,
+				})
+				if err != nil {
+					return err
+				}
+				cons.M.Lock()
+				racc, ok := cons.Accs[id]
+				if !ok {
+					cons.Accs[id] = myacc
+					acc = myacc
+				} else {
+					acc = racc
+				}
+				cons.M.Unlock()
+			}
+			for _, s := range ts.Samples {
+				err := acc.Append(s)
+				if err != nil {
+					return err
+				}
+				c.samplesTotal.WithLabelValues(topic, partitionStr).Inc()
+			}
+		}
+		err = twc.CommitOffset(msg.Offset)
+		if err != nil {
+			return err
+		}
+	}
+	return twc.Err()
+}
+
+func (c *Cacher) handle(ctx context.Context, topic string, partition int32) {
+	log := logrus.WithFields(logrus.Fields{
+		"topic":     topic,
+		"partition": partition,
+	})
+	log.Info("taking control of topic-partition")
+	count := 0
+	backoff := time.NewTimer(time.Duration(0))
+	for {
+		count++
+		select {
+		case <-ctx.Done():
+			return
+		case <-backoff.C:
+			err := c.consume(ctx, topic, partition)
+			if err == nil {
+				logrus.WithFields(logrus.Fields{
+					"topic":     topic,
+					"partition": partition,
+				}).Info("relenquishing control of topic-partition")
+				return
+			}
+			// exponential backoff with cap at 10m
+			dur := time.Duration(math.Min(float64(time.Minute*10), float64(100*time.Millisecond)*math.Pow(float64(2), float64(count))))
+			logrus.WithFields(logrus.Fields{
+				"backoff_duration": dur,
+				"topic":            topic,
+				"partition":        partition,
+			}).WithError(err).Error("error while consuming but restarting after backoff")
+			backoff.Reset(dur)
+		}
+	}
+}
+
+// Run blocks until cacher is done or errors.
+func (c *Cacher) Run() error {
+	return c.cfg.Coordinator.Run(c.handle)
+}
+
+func parseTimeSeriesBatch(in []byte) (model.TimeSeriesBatch, error) {
+	wr := &remote.WriteRequest{}
+	if err := proto.Unmarshal(in, wr); err != nil {
+		return nil, err
+	}
+	tsb := make(model.TimeSeriesBatch, 0, len(wr.Timeseries))
+	for _, protots := range wr.Timeseries {
+		ts := &model.TimeSeries{
+			Labels:  map[string]string{},
+			Samples: make([]*model.Sample, 0, len(protots.Samples)),
+		}
+		for _, pair := range protots.Labels {
+			ts.Labels[pair.Name] = pair.Value
+		}
+		for _, protosamp := range protots.Samples {
+			ts.Samples = append(ts.Samples, &model.Sample{
+				TimestampMS: protosamp.TimestampMs,
+				Value:       protosamp.Value,
+			})
+		}
+		tsb = append(tsb, ts)
+	}
+	return tsb, nil
+}

--- a/cacher/http.go
+++ b/cacher/http.go
@@ -1,0 +1,43 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cacher
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// chunksResp is returned over HTTP and JSON encoded.
+type chunksResp struct {
+	Chunks [][]byte `json:"chunks"`
+}
+
+// getChunks attempts to read an URL for a chunksResp.
+func getChunks(u *url.URL) (*chunksResp, error) {
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("received status %s", resp.Status)
+	}
+	dec := json.NewDecoder(resp.Body)
+	var cr chunksResp
+	err = dec.Decode(&cr)
+	return &cr, err
+}

--- a/cacher/iterator_factory.go
+++ b/cacher/iterator_factory.go
@@ -1,0 +1,155 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cacher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/digitalocean/vulcan/convert"
+	"github.com/digitalocean/vulcan/kafka"
+	"github.com/digitalocean/vulcan/model"
+	pmodel "github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/local"
+	"github.com/prometheus/prometheus/storage/metric"
+)
+
+// IteratorFactory is able to create SeriesIterator that talk to a IteratorFactory.
+// This bridges the new series iterator prometheus interface to our older cassandra
+// code that was built for a different interface. Eventually, a cassandra storage
+// object should just be able to create iterators directly.
+type IteratorFactory struct {
+	cfg            *IteratorFactoryConfig
+	partitionAddrs map[int32]string
+	partitions     []int32
+	m              sync.Mutex
+}
+
+// IteratorFactoryConfig is necessary to create a new IteratorFactory.
+type IteratorFactoryConfig struct {
+	Client  sarama.Client
+	Context context.Context
+	GroupID string
+	Topic   string
+	Refresh time.Duration
+}
+
+// NewIteratorFactory creates and starts the background process for an IteratorFactory.
+func NewIteratorFactory(cfg *IteratorFactoryConfig) (*IteratorFactory, error) {
+	itrf := &IteratorFactory{
+		cfg:            cfg,
+		partitionAddrs: map[int32]string{},
+		partitions:     []int32{},
+	}
+	go itrf.run()
+	return itrf, nil
+}
+
+func (itrf *IteratorFactory) run() error {
+	t := time.NewTimer(0)
+	for {
+		select {
+		case <-itrf.cfg.Context.Done():
+			return nil
+		case <-t.C:
+			t.Reset(itrf.cfg.Refresh)
+			err := itrf.fetchAndSet()
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (itrf *IteratorFactory) fetchAndSet() error {
+	itrf.m.Lock()
+	defer itrf.m.Unlock()
+	b, err := itrf.cfg.Client.Coordinator(itrf.cfg.GroupID)
+	if err != nil {
+		return err
+	}
+	partitions, err := itrf.cfg.Client.Partitions(itrf.cfg.Topic)
+	if err != nil {
+		return err
+	}
+	itrf.partitions = partitions
+	resp, err := b.DescribeGroups(&sarama.DescribeGroupsRequest{
+		Groups: []string{itrf.cfg.GroupID},
+	})
+	if err != nil {
+		return err
+	}
+	for _, group := range resp.Groups {
+		if group.GroupId != itrf.cfg.GroupID {
+			continue
+		}
+		for _, member := range group.Members {
+			meta, err := member.GetMemberMetadata()
+			if err != nil {
+				return err
+			}
+			var us model.UserData
+			err = json.Unmarshal(meta.UserData, &us)
+			if err != nil {
+				return err
+			}
+			assg, err := member.GetMemberAssignment()
+			if err != nil {
+				return err
+			}
+			for topic, partitions := range assg.Topics {
+				if topic != itrf.cfg.Topic {
+					continue
+				}
+				for _, partition := range partitions {
+					itrf.partitionAddrs[partition] = us.AdvertisedAddr
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Iterator returns a new SeriesIterator.
+func (itrf *IteratorFactory) Iterator(m metric.Metric, from, through pmodel.Time) (local.SeriesIterator, error) {
+	ts := convert.MetricToTimeSeries(m)
+	key := kafka.Key(kafka.Job(ts.Labels["job"]), kafka.Instance(ts.Labels["instance"]))
+	p := kafka.HashNegativeAndReflectInsanity(key, len(itrf.partitions))
+	itrf.m.Lock()
+	addr, ok := itrf.partitionAddrs[p]
+	itrf.m.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("could not find host handling partition %d", p)
+	}
+	v := url.Values{}
+	v.Set("id", ts.ID())
+	u := &url.URL{
+		Scheme:   "http",
+		Host:     addr,
+		Path:     "chunks",
+		RawQuery: v.Encode(),
+	}
+	return NewSeriesIterator(&SeriesIteratorConfig{
+		Metric: m,
+		After:  from,
+		Before: through,
+		URL:    u,
+	}), nil
+}

--- a/cacher/iterator_test.go
+++ b/cacher/iterator_test.go
@@ -1,0 +1,20 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cacher
+
+import "github.com/prometheus/prometheus/storage/local"
+
+// ensure that SeriesIterator implements the Prometheus SeriesIterator interface.
+var _ local.SeriesIterator = &SeriesIterator{}

--- a/cmd/cacher.go
+++ b/cmd/cacher.go
@@ -1,0 +1,134 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/Sirupsen/logrus"
+	"github.com/digitalocean/vulcan/cacher"
+	"github.com/digitalocean/vulcan/model"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	cg "github.com/supershabam/sarama-cg"
+	"github.com/supershabam/sarama-cg/protocol"
+)
+
+// Cacher is an in-memory cache for samples that the querier uses to serve queries for data
+// that has not yet been compacted and persisted by the compactor.
+func Cacher() *cobra.Command {
+	cchr := &cobra.Command{
+		Use:   "cacher",
+		Short: "cacher keeps recent metrics from the bus in-memory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO make advertised addr more configurable..
+			hostname, err := os.Hostname()
+			if err != nil {
+				return err
+			}
+			port := viper.GetInt(flagCacherPort)
+			addr := fmt.Sprintf("%s:%d", hostname, port)
+			ud, err := json.Marshal(model.UserData{
+				AdvertisedAddr: addr,
+			})
+			if err != nil {
+				return err
+			}
+			kafkaAddrs := strings.Split(viper.GetString(flagKafkaAddrs), ",")
+			clientID := viper.GetString(flagKafkaClientID)
+			groupID := viper.GetString(flagKafkaGroupID)
+
+			logrus.WithFields(logrus.Fields{
+				"kafka_addrs":     kafkaAddrs,
+				"kafka_client_id": clientID,
+				"kafka_group_id":  groupID,
+			}).Info("starting cacher")
+
+			cfg := sarama.NewConfig()
+			cfg.Version = sarama.V0_10_0_0
+			cfg.ClientID = clientID
+			client, err := sarama.NewClient(kafkaAddrs, cfg)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			term := make(chan os.Signal, 1)
+			signal.Notify(term, os.Interrupt, syscall.SIGTERM)
+			go func() {
+				<-term
+				logrus.Info("shutting down...")
+				cancel()
+				<-term
+				os.Exit(1)
+			}()
+			coord := cg.NewCoordinator(&cg.CoordinatorConfig{
+				Client:  client,
+				Context: ctx,
+				GroupID: groupID,
+				Protocols: []cg.ProtocolKey{
+					{
+						Protocol: &protocol.HashRing{
+							MyUserData: ud,
+						},
+						Key: "hashring",
+					},
+				},
+				SessionTimeout: viper.GetDuration(flagKafkaSession),
+				Heartbeat:      viper.GetDuration(flagKafkaHeartbeat),
+				Topics:         []string{viper.GetString(flagKafkaTopic)},
+			})
+			c, err := cacher.NewCacher(&cacher.Config{
+				Cleanup:     viper.GetDuration(flagCacherCleanup),
+				Client:      client,
+				Coordinator: coord,
+				MaxAge:      viper.GetDuration(flagCacherMaxAge),
+				Topic:       viper.GetString(flagKafkaTopic),
+			})
+			if err != nil {
+				return err
+			}
+			prometheus.MustRegister(c)
+			go func() {
+				http.Handle("/metrics", prometheus.Handler())
+				http.Handle("/chunks", c)
+				http.ListenAndServe(addr, nil)
+			}()
+			logrus.Info("running")
+			return c.Run()
+		},
+	}
+
+	cchr.Flags().Duration(flagCacherCleanup, time.Minute*10, "garbage collection interval for cacher")
+	cchr.Flags().Duration(flagCacherMaxAge, time.Hour*4, "max age of samples to keep in-memory")
+	cchr.Flags().Int(flagCacherPort, 8080, "port to listen on")
+	cchr.Flags().String(flagKafkaAddrs, "", "one.example.com:9092,two.example.com:9092")
+	cchr.Flags().String(flagKafkaClientID, "vulcan-cacher", "set the kafka client id")
+	cchr.Flags().String(flagKafkaGroupID, "vulcan-cacher", "workers with the same groupID will join the same Kafka ConsumerGroup")
+	cchr.Flags().Duration(flagKafkaHeartbeat, time.Second*3, "kafka consumer group heartbeat interval")
+	cchr.Flags().Duration(flagKafkaSession, time.Second*30, "kafka consumer group session duration")
+	cchr.Flags().String(flagKafkaTopic, "vulcan", "set the kafka topic to consume")
+
+	return cchr
+}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -22,9 +22,9 @@ const (
 // Vulcan command line flag names.
 const (
 	flagAddress               = "address"
+	flagAdvertise             = "advertise"
 	flagCacherCleanup         = "cacher-cleanup"
 	flagCacherMaxAge          = "cacher-max-age"
-	flagCacherPort            = "cacher-port"
 	flagCassandraAddrs        = "cassandra-addrs"
 	flagCassandraKeyspace     = "cassandra-keyspace"
 	flagCassandraPageSize     = "cassandra-page-size"

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -22,6 +22,9 @@ const (
 // Vulcan command line flag names.
 const (
 	flagAddress               = "address"
+	flagCacherCleanup         = "cacher-cleanup"
+	flagCacherMaxAge          = "cacher-max-age"
+	flagCacherPort            = "cacher-port"
 	flagCassandraAddrs        = "cassandra-addrs"
 	flagCassandraKeyspace     = "cassandra-keyspace"
 	flagCassandraPageSize     = "cassandra-page-size"
@@ -33,7 +36,9 @@ const (
 	flagESSniff               = "es-sniff"
 	flagKafkaAddrs            = "kafka-addrs"
 	flagKafkaClientID         = "kafka-client-id"
+	flagKafkaHeartbeat        = "kafka-heartbeat"
 	flagKafkaGroupID          = "kafka-group-id"
+	flagKafkaSession          = "kafka-session"
 	flagKafkaTopic            = "kafka-topic"
 	flagKafkaBatchSize        = "kafka-batch-size"
 	flagNumCassandraWorkers   = "num-cassandra-workers"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d74dc772cdfe72c3ef716579a3dfcb761ba2bb5b71825d8592f0c564e0b84b00
-updated: 2016-10-25T18:48:13.595582071-06:00
+hash: fd8847d21d2606b8ccbff5483d5f30b97b3e79568b00c14caa98963f207a2ea0
+updated: 2016-11-14T13:53:31.638658961-07:00
 imports:
 - name: cloud.google.com/go
   version: 07f82cd40595eddb6b6500701401032dd0bd92e0
@@ -187,12 +187,17 @@ imports:
   - web
   - web/api/v1
   - web/ui
+- name: github.com/rcrowley/go-metrics
+  version: ab2277b1c5d15c3cba104e9cbddbdfc622df5ad8
 - name: github.com/samuel/go-zookeeper
   version: 87e1bca4477a3cc767ca71be023ced183d74e538
   subpackages:
   - zk
+- name: github.com/serialx/hashring
+  version: 75d57fa264ad17fd929304dfdb02c8e278c5c01c
 - name: github.com/Shopify/sarama
-  version: bd61cae2be85fa6ff40eb23dcdd24567967ac2ae
+  version: f672ba54efeac37acc7a48c3c0cc732e402fcf34
+  repo: https://github.com/supershabam/sarama
 - name: github.com/Sirupsen/logrus
   version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: github.com/spf13/afero
@@ -210,6 +215,11 @@ imports:
   version: c7e63cf4530bcd3ba943729cee0efeff2ebea63f
 - name: github.com/spf13/viper
   version: 2f6a41490bc86fa9a8fb2fc03526a5795e904a17
+- name: github.com/supershabam/sarama-cg
+  version: 5cb9221bf2fa72d1ec8066e564512e43b5744242
+  subpackages:
+  - consumer
+  - protocol
 - name: github.com/syndtr/goleveldb
   version: 6ae1797c0b42b9323fc27ff7dcf568df88f2f33d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,8 @@ import:
   subpackages:
   - model  
 - package: github.com/Shopify/sarama
-  version: v1.10.1
+  version: f672ba54efeac37acc7a48c3c0cc732e402fcf34
+  repo: https://github.com/supershabam/sarama
 - package: github.com/Sirupsen/logrus
   version: v0.10.0
 - package: github.com/gocql/gocql
@@ -31,3 +32,5 @@ import:
   version: 0.7.0
 - package: github.com/bsm/sarama-cluster
   version: v2.1.1
+- package: github.com/supershabam/sarama-cg
+  version: 5cb9221bf2fa72d1ec8066e564512e43b5744242

--- a/kafka/hash.go
+++ b/kafka/hash.go
@@ -1,0 +1,33 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import "hash/fnv"
+
+// HashNegativeAndReflectInsanity matches the partition hashing algorithm found in the
+// sarama golang kafka driver. Casting a uint32 to an int and then handling the negative
+// by negating the number seems insane, but return int32(h.Sum32() % uint32(count)) is not
+// the same.
+func HashNegativeAndReflectInsanity(key []byte, count int) int32 {
+	h := fnv.New32a()
+	// Write (via the embedded io.Writer interface) adds more data to the running hash.
+	// It never returns an error.
+	h.Write(key)
+	p := int32(h.Sum32()) % int32(count)
+	if p < 0 {
+		p = -p
+	}
+	return p
+}

--- a/kafka/hash_test.go
+++ b/kafka/hash_test.go
@@ -1,0 +1,43 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka_test
+
+import (
+	"testing"
+
+	"github.com/digitalocean/vulcan/kafka"
+)
+
+const (
+	magicCountPartitions int = 48
+)
+
+func TestNegativeHashAndReflectInsanity(t *testing.T) {
+	tests := []struct {
+		Key       []byte
+		Partition int32
+	}{
+		{
+			Key:       []byte("prometheus-localhost:9090"),
+			Partition: 39,
+		},
+	}
+	for _, test := range tests {
+		p := kafka.HashNegativeAndReflectInsanity(test.Key, magicCountPartitions)
+		if p != test.Partition {
+			t.Errorf("for %s expected %d but got %d", test.Key, test.Partition, p)
+		}
+	}
+}

--- a/kafka/key.go
+++ b/kafka/key.go
@@ -1,0 +1,36 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+// Job is necessary for creating kafka routing key. It's its own type mostly to protect the
+// user from inadvertently swapping the order of Job and Instance to the Key function.
+type Job string
+
+// Instance is necessary for creating a kafka routing key. It's its own type mostly to protect the
+// user from inadvertently swapping the order of Job and Instance to the Key function.
+type Instance string
+
+const separator byte = '-'
+
+// Key returns a routing key from a job and instance. Since this is called many many times,
+// we build the result byte slice with a pre-allocated buffer and copy instead of a simple
+// fmt.Sprintf call.
+func Key(job Job, instance Instance) []byte {
+	buf := make([]byte, len(job)+len(instance)+1)
+	copy(buf, job)
+	buf[len(job)] = separator
+	copy(buf[len(job)+1:], instance)
+	return buf
+}

--- a/kafka/key_test.go
+++ b/kafka/key_test.go
@@ -1,0 +1,46 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka_test
+
+import (
+	"testing"
+
+	"github.com/digitalocean/vulcan/kafka"
+)
+
+func TestKey(t *testing.T) {
+	tests := []struct {
+		Job      string
+		Instance string
+		Result   []byte
+	}{
+		{
+			Job:      "www",
+			Instance: "node01.example.com:8080",
+			Result:   []byte("www-node01.example.com:8080"),
+		},
+		{
+			Job:      "⌘",
+			Instance: "世界",
+			Result:   []byte("⌘-世界"),
+		},
+	}
+	for _, test := range tests {
+		key := kafka.Key(kafka.Job(test.Job), kafka.Instance(test.Instance))
+		if string(key) != string(test.Result) {
+			t.Errorf("unexpected result got=%s want=%s", key, test.Result)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 	}
 	vulcan.PersistentFlags().String("log-level", "info", "The level of logging (panic|fatal|error|warn|info|debug)")
 
+	vulcan.AddCommand(cmd.Cacher())
 	vulcan.AddCommand(cmd.Indexer())
 	vulcan.AddCommand(cmd.Ingester())
 	vulcan.AddCommand(cmd.Querier())

--- a/model/userdata.go
+++ b/model/userdata.go
@@ -1,0 +1,20 @@
+// Copyright 2016 The Vulcan Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+// UserData is saved with a Kafka protocol upon a consumer joining a group.
+type UserData struct {
+	AdvertisedAddr string `json:"advertisedAddr"`
+}


### PR DESCRIPTION
The cacher combined with the compressor is meant to replace the "ingester" part of Vulcan. The cacher keeps a configurable window of most recent samples from Kafka in-memory. The querier serves all the samples it can from compressed/persisted chunks stored in Cassandra, and then gets the most recent metric samples from the cacher.

The cacher stores metrics in-memory in varbit-encoded chunks for memory efficiency and also returns results to the querier in varbit-encoded responses to minimize network transfer.

This PR is a first pass at a cacher that can share load among other cachers via a Kafka consumer group and advertise how to connect to the cacher via Kafka metadata.

Following PRs will be for the compressor, and a querier that knows how to utilize both the cacher and compressor data.

Future improvements would be redundant handling of a kafka partition by multiple cachers and a querier that can load balance across the multiple cachers for a single partition. Also, a smarter partition-assignment strategy to make sure that cachers are evenly loaded. The HTTP api currently implemented by the cacher could also be improved.