### PR TITLE
glide: update v0.12.3; remove vendor's vendor automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
   # install golint
   - go get github.com/golang/lint/golint
   # install glide
-  - curl -fsSL https://github.com/Masterminds/glide/releases/download/v0.12.2/glide-v0.12.2-linux-amd64.tar.gz -o glide.tar.gz
-  - echo "edd398b4e94116b289b9494d1c13ec2ea37386bad4ada91ecc9825f96b12143c  glide.tar.gz" | sha256sum -c -
+  - curl -fsSL https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz -o glide.tar.gz
+  - echo "0e2be5e863464610ebc420443ccfab15cdfdf1c4ab63b5eb25d1216900a75109  glide.tar.gz" | sha256sum -c -
   - tar -xf glide.tar.gz --strip-components=1 -C "$GOPATH/bin" linux-amd64/glide
   - rm glide.tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,7 @@ glide.lock: glide.yaml
 
 .makecache/vendor: .makecache glide.lock glide.yaml $(VENDOR_SRCS)
 	@echo ">> installing golang dependencies into vendor directory"
-	@glide install
-	@echo ">> removing dependencies' committed vendor directories"
-	@rm -fr vendor/github.com/prometheus/prometheus/vendor
+	@glide install -v
 	@touch $@
 
 target/vulcan_linux_amd64: .makecache/vendor $(VULCAN_SRCS)


### PR DESCRIPTION
Updates travis install of glide to v0.12.3.

Updates makefile command to install dependencies to use the "-v" flag which tells glide to remove our depedencies' vendor directories instead of manually running a "rm -fr ..." command in the makefile.